### PR TITLE
Allow text selection in dataview

### DIFF
--- a/shared/inspector/v2/inspector.module.scss
+++ b/shared/inspector/v2/inspector.module.scss
@@ -93,6 +93,8 @@
 
 .typeName {
   color: var(--type-color);
+  user-select: none;
+  pointer-events: none;
 }
 
 .scalar_string {

--- a/shared/studio/tabs/dataview/dataInspector.module.scss
+++ b/shared/studio/tabs/dataview/dataInspector.module.scss
@@ -235,6 +235,10 @@
   font-family: Roboto Mono;
   font-weight: normal;
   font-size: 14px;
+
+  &.selectable {
+    user-select: text;
+  }
 }
 
 .loadingCell {
@@ -440,6 +444,8 @@
     margin-left: var(--rowIndexWidth);
     display: flex;
     align-items: center;
+    user-select: text;
+    width: 100%;
     z-index: 1;
   }
 
@@ -458,6 +464,7 @@
     padding: 0 8px;
     margin-left: 1rem;
     cursor: pointer;
+    user-select: none;
 
     @include darkTheme {
       border: 1px solid #7c7c7c;

--- a/shared/studio/tabs/dataview/dataInspector.tsx
+++ b/shared/studio/tabs/dataview/dataInspector.tsx
@@ -360,6 +360,7 @@ const GridCell = observer(function GridCell({
   }
 
   let content: JSX.Element | null = null;
+  let selectable = false;
   if (isEmptySubtype) {
     content = <span className={styles.emptySubtypeField}>-</span>;
   } else if (data) {
@@ -392,6 +393,7 @@ const GridCell = observer(function GridCell({
               {undoEdit}
             </>
           );
+          selectable = true;
         }
       }
     } else {
@@ -451,6 +453,7 @@ const GridCell = observer(function GridCell({
   return (
     <div
       className={cn(styles.cell, {
+        [styles.selectable]: selectable,
         [styles.loadingCell]: !data,
         [styles.isDeleted]:
           isDeletedRow ||


### PR DESCRIPTION
This is a temporary (partial) fix for #41/#64. In the future I'm thinking we should implement a more spreadsheet like selection behaviour, where you can select cells/ranges of cells, and there be a popup contexual ui with structured copy options (eg. copy as table, copy as json, copy as csv/tsv). This is also needed for the planned 'extended dataviewers'.