### PR TITLE
Repl updates

### DIFF
--- a/shared/codeEditor/completions.ts
+++ b/shared/codeEditor/completions.ts
@@ -17,10 +17,11 @@ function sliceDoc(doc: Text, range: {from: number; to: number}): string {
 function isKeyword(
   doc: Text,
   node: SyntaxNode | null,
-  keyword: string
+  keywords: string[]
 ): boolean {
   return (
-    node?.name === "Keyword" && sliceDoc(doc, node).toLowerCase() === keyword
+    node?.name === "Keyword" &&
+    keywords.includes(sliceDoc(doc, node).toLowerCase())
   );
 }
 
@@ -29,9 +30,41 @@ function stripModuleName(typename: string): string {
   return module === "default" ? name : typename;
 }
 
+function getKeywordAndName(
+  doc: Text,
+  node: SyntaxNode,
+  nested: boolean
+): {keyword: "select" | "insert" | "update"; name: string} | null {
+  if (node.name === "Name" && node.prevSibling?.name === "Keyword") {
+    const keyword = sliceDoc(doc, node.prevSibling).toLowerCase();
+    if (keyword === "select" || (!nested && keyword === "insert")) {
+      return {keyword, name: sliceDoc(doc, node)};
+    }
+    return null;
+  }
+  if (!nested && isKeyword(doc, node, ["set"])) {
+    let prevNode = node.prevSibling;
+    while (prevNode) {
+      if (isKeyword(doc, prevNode, ["update"])) {
+        if (prevNode.nextSibling?.name === "Name") {
+          return {
+            keyword: "update",
+            name: sliceDoc(doc, prevNode.nextSibling),
+          };
+        }
+        return null;
+      }
+      prevNode = prevNode.prevSibling;
+    }
+    return null;
+  }
+  return null;
+}
+
 export function getCompletions(schemaObjects: Map<string, SchemaObjectType>) {
   const userSchemaObjects = [...schemaObjects.values()].filter(
-    (obj) => !obj.builtin && !obj.unionOf && !obj.insectionOf
+    (obj) =>
+      !obj.builtin && !obj.unionOf && !obj.insectionOf && !obj.from_alias
   );
 
   return function completions(
@@ -51,13 +84,24 @@ export function getCompletions(schemaObjects: Map<string, SchemaObjectType>) {
     }
 
     if (
-      (isKeyword(doc, node, "select") && node.to < pos) ||
-      (node?.name === "Name" && isKeyword(doc, node.prevSibling, "select"))
+      (isKeyword(doc, node, ["select", "insert", "update", "delete"]) &&
+        node.to < pos) ||
+      (node?.name === "Name" &&
+        isKeyword(doc, node.prevSibling, [
+          "select",
+          "insert",
+          "update",
+          "delete",
+        ]))
     ) {
+      const isDelete =
+        isKeyword(doc, node, ["delete"]) ||
+        isKeyword(doc, node.prevSibling, ["delete"]);
       return {
         from: node?.name === "Keyword" ? context.pos : node.from,
         options: userSchemaObjects.map((obj) => ({
           label: stripModuleName(obj.name),
+          apply: isDelete ? `${stripModuleName(obj.name)} filter ` : undefined,
         })),
         validFor: (text, from, to, state) => {
           return syntaxTree(state).resolveInner(to, -1)?.name === "Name";
@@ -74,12 +118,13 @@ export function getCompletions(schemaObjects: Map<string, SchemaObjectType>) {
       ) {
         let path: string[] = [];
         let prevNode = node.prevSibling;
+
         while (true) {
-          if (
-            prevNode?.name === "Name" &&
-            isKeyword(doc, prevNode.prevSibling, "select")
-          ) {
-            let typeName = sliceDoc(doc, prevNode);
+          const keywordAndName =
+            prevNode && getKeywordAndName(doc, prevNode, path.length > 0);
+          if (keywordAndName) {
+            const keyword = keywordAndName.keyword;
+            let typeName = keywordAndName.name;
             if (!typeName.includes("::")) {
               typeName = "default::" + typeName;
             }
@@ -100,37 +145,49 @@ export function getCompletions(schemaObjects: Map<string, SchemaObjectType>) {
               return {
                 from: pos,
                 options: [
-                  {
-                    label: "*",
-                    apply: [
-                      ...Object.values(typeObj.properties).map(
-                        (prop) => prop.name
-                      ),
-                      ...Object.values(typeObj.links).map(
-                        (link) => `${link.name}: {}`
-                      ),
-                    ].join(`,\n${" ".repeat(pos - doc.lineAt(pos).from)}`),
-                  },
+                  ...(keyword === "select"
+                    ? [
+                        {
+                          label: "*",
+                          apply: [
+                            ...Object.values(typeObj.properties).map(
+                              (prop) => prop.name
+                            ),
+                            ...Object.values(typeObj.links).map(
+                              (link) => `${link.name}: {}`
+                            ),
+                          ].join(
+                            `,\n${" ".repeat(pos - doc.lineAt(pos).from)}`
+                          ),
+                        },
+                      ]
+                    : []),
                   ...Object.values(typeObj.properties).map((prop) => ({
                     label: prop.name,
-                    apply: prop.name + ",",
+                    apply: prop.name + (keyword === "select" ? "," : " := "),
                   })),
                   ...Object.values(typeObj.links).map((link) => ({
                     label: link.name,
-                    apply: (
-                      view: EditorView,
-                      completion: Completion,
-                      from: number
-                    ) => {
-                      view.dispatch({
-                        changes: {from, insert: `${completion.label}: {},`},
-                        selection: {
-                          anchor: from + completion.label.length + 3,
-                        },
-                        userEvent: "input.complete",
-                        annotations: pickedCompletion.of(completion),
-                      });
-                    },
+                    apply:
+                      keyword === "select"
+                        ? (
+                            view: EditorView,
+                            completion: Completion,
+                            from: number
+                          ) => {
+                            view.dispatch({
+                              changes: {
+                                from,
+                                insert: `${completion.label}: {},`,
+                              },
+                              selection: {
+                                anchor: from + completion.label.length + 3,
+                              },
+                              userEvent: "input.complete",
+                              annotations: pickedCompletion.of(completion),
+                            });
+                          }
+                        : link.name + " := ",
                   })),
                 ],
               };

--- a/shared/inspector/v2/buildItem.tsx
+++ b/shared/inspector/v2/buildItem.tsx
@@ -149,14 +149,26 @@ export function expandItem(
                         (item.parent as any).data.id,
                         item.fieldName!
                       );
-                      (item.parent as any).data[item.fieldName!] = data;
                       const codecIndex = (
                         item.parent as any
                       ).codec.fields.findIndex(
                         (f: any) => f.name === item.fieldName!
                       );
-                      (item.parent as any).codec.codecs[codecIndex].subCodec =
-                        codec;
+                      if (
+                        (
+                          (item.parent as any).codec.codecs[
+                            codecIndex
+                          ] as _ICodec
+                        ).getKind() === "object"
+                      ) {
+                        (item.parent as any).data[item.fieldName!] = data[0];
+                        (item.parent as any).codec.codecs[codecIndex] = codec;
+                      } else {
+                        (item.parent as any).data[item.fieldName!] = data;
+                        (item.parent as any).codec.codecs[
+                          codecIndex
+                        ].subCodec = codec;
+                      }
                       const parentIndex = state._items.indexOf(item.parent!);
                       state.collapseItem(parentIndex);
                       state.expandItem(parentIndex);

--- a/shared/inspector/v2/buildScalar.tsx
+++ b/shared/inspector/v2/buildScalar.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren} from "react";
+import {PropsWithChildren} from "react";
 import {LocalDateTime, _ICodec, Range} from "edgedb";
 
 import cn from "@edgedb/common/utils/classNames";
@@ -19,6 +19,7 @@ export function buildScalarItem(
     label?: JSX.Element;
   },
   data: any,
+  index: string | number,
   comma?: boolean
 ): Item {
   const {body, height} = renderValue(
@@ -33,13 +34,10 @@ export function buildScalarItem(
   return {
     ...base,
     type: ItemType.Scalar,
-    height: height,
-    body: (
-      <>
-        {body}
-        {comma ? "," : ""}
-      </>
-    ),
+    index,
+    height,
+    body,
+    comma,
   };
 }
 

--- a/shared/inspector/v2/inspector.module.scss
+++ b/shared/inspector/v2/inspector.module.scss
@@ -17,13 +17,20 @@
 }
 
 .inspector {
-  margin: 10px 0;
-
   @extend .inspectorTheme;
 
   & * {
     box-sizing: border-box;
   }
+
+  .innerWrapper {
+    width: max-content;
+    min-width: 100%;
+  }
+}
+
+.rowWrapper {
+  position: relative;
 }
 
 .rowItem {
@@ -32,30 +39,85 @@
   padding: var(--rowPad) 0;
   white-space: pre;
 
-  border-radius: 4px;
-
   .jsonMode & {
     padding-left: 0 !important;
   }
+
+  &.hoverable:hover {
+    background: var(--inspectorRowHoverBg, #ebebeb);
+
+    .copyButton {
+      opacity: 1;
+    }
+
+    :global(.dark-theme) & {
+      background: var(--inspectorRowHoverBg, #303030);
+    }
+  }
+
+  .itemContent,
+  .itemBody {
+    display: flex;
+    padding: 0 2px;
+    margin: 0 -2px;
+    border-radius: 2px;
+  }
+
+  .itemContent {
+    margin-right: auto;
+  }
+
+  &.highlightBody {
+    .itemBody {
+      background: Highlight;
+
+      &,
+      & * {
+        color: HighlightText !important;
+      }
+    }
+  }
+
+  &.highlightAll {
+    .itemContent {
+      background: Highlight;
+
+      &,
+      & * {
+        color: HighlightText !important;
+      }
+    }
+  }
+}
+
+.comma {
+  align-self: flex-end;
 }
 
 .expandArrow {
   display: flex;
   align-items: center;
+  justify-content: center;
   width: 24px;
   height: var(--lineHeight);
   margin-left: -24px;
   cursor: pointer;
+  transform: rotate(-90deg);
   transition: transform 0.1s;
 
   &.expanded {
-    transform: rotate(90deg);
+    transform: rotate(0);
+  }
+
+  svg {
+    width: 11px;
   }
 }
 
 .ellipsis {
   border: 1px solid #ccc;
   background: #eee;
+  fill: #4d4d4d;
   user-select: none;
   height: 12px;
   margin: 0 3px;
@@ -68,6 +130,48 @@
   :global(.dark-theme) & {
     border-color: #636363;
     background: #3d3d3d;
+    fill: #e7e7e7;
+  }
+}
+
+.copyButton {
+  display: flex;
+  align-items: center;
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 24px;
+  text-transform: uppercase;
+  color: #a2a2a2;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--inspectorRowHoverBg, #ebebeb) 8px,
+    var(--inspectorRowHoverBg, #ebebeb)
+  );
+  padding: 0 8px;
+  padding-left: 16px;
+  opacity: 0;
+  cursor: pointer;
+  position: sticky;
+  right: 0;
+
+  svg {
+    fill: currentColor;
+  }
+
+  &:hover {
+    color: #1f8aed;
+  }
+
+  :global(.dark-theme) & {
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--inspectorRowHoverBg, #303030) 8px,
+      var(--inspectorRowHoverBg, #303030)
+    );
   }
 }
 

--- a/shared/inspector/v2/renderJsonResult.ts
+++ b/shared/inspector/v2/renderJsonResult.ts
@@ -1,7 +1,7 @@
 import type {_ICodec as ICodec} from "edgedb";
 import type {ObjectCodec} from "edgedb/dist/codecs/object";
 import type {NamedTupleCodec} from "edgedb/dist/codecs/namedtuple";
-import {scalarItemToString} from "@edgedb/inspector/v2/buildScalar";
+import {scalarItemToString} from "./buildScalar";
 
 export function renderResultAsJson(result: any, codec: ICodec): string {
   return `[\n${(result as any[])
@@ -9,7 +9,7 @@ export function renderResultAsJson(result: any, codec: ICodec): string {
     .join(",\n")}\n]`;
 }
 
-function _renderToJson(val: any, codec: ICodec, depth: string): string {
+export function _renderToJson(val: any, codec: ICodec, depth: string): string {
   if (val == null) {
     return "null";
   }

--- a/shared/inspector/v2/state.ts
+++ b/shared/inspector/v2/state.ts
@@ -9,8 +9,9 @@ import {
   _async,
   _await,
   ArraySet,
+  idProp,
 } from "mobx-keystone";
-import {observable} from "mobx";
+import {action, observable} from "mobx";
 import {_ICodec} from "edgedb";
 import {Item, buildItem, expandItem, ItemType} from "./buildItem";
 
@@ -34,6 +35,7 @@ export type NestedDataGetter = (
 
 @model("edb/Inspector")
 export class InspectorState extends Model({
+  $modelId: idProp,
   expanded: prop<ArraySet<string> | undefined>(),
   scrollPos: prop<number>(0).withSetter(),
 
@@ -46,6 +48,14 @@ export class InspectorState extends Model({
   _jsonMode = false;
 
   loadingData = false;
+
+  @observable
+  hoverId: string | null = null;
+
+  @action.bound
+  setHoverId(id: string | null) {
+    this.hoverId = id;
+  }
 
   loadNestedData: NestedDataGetter | null = null;
 
@@ -92,7 +102,8 @@ export class InspectorState extends Model({
             level: 0,
             codec: result.codec,
           },
-          jsonMode ? `[${result.data.join(", ")}]` : result.data
+          jsonMode ? `[${result.data.join(", ")}]` : result.data,
+          0
         ),
       ];
       if (!jsonMode) {

--- a/shared/inspector/v2/styles.d.ts
+++ b/shared/inspector/v2/styles.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.scss" {
+  const classes: {[key: string]: string};
+  export default classes;
+}

--- a/shared/inspector/v2/tsconfig.json
+++ b/shared/inspector/v2/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "experimentalDecorators": true,
+    "downlevelIteration": true
+  }
+}

--- a/shared/studio/state/settings.ts
+++ b/shared/studio/state/settings.ts
@@ -1,0 +1,28 @@
+import {fromSnapshot, Model, model, onSnapshot, prop} from "mobx-keystone";
+
+@model("Settings")
+export class Settings extends Model({
+  disableAccessPolicies: prop<boolean>(false).withSetter(),
+  persistQuery: prop<boolean>(false).withSetter(),
+}) {}
+
+const localStorageKey = "edgedbStudioSettings";
+
+let settingsState: Settings;
+const storedSettings = localStorage.getItem(localStorageKey);
+if (storedSettings) {
+  try {
+    settingsState = fromSnapshot(Settings, JSON.parse(storedSettings));
+  } catch {
+    // ignore deserialisation errors
+  }
+}
+if (!settingsState!) {
+  settingsState = new Settings({});
+}
+
+export {settingsState};
+
+onSnapshot(settingsState, (snapshot) => {
+  localStorage.setItem(localStorageKey, JSON.stringify(snapshot));
+});

--- a/shared/studio/tabs/repl/index.tsx
+++ b/shared/studio/tabs/repl/index.tsx
@@ -21,6 +21,7 @@ import ReplHistory from "./replHistory";
 import ParamEditorPanel from "./paramEditor";
 import {KebabMenuIcon, TabReplIcon} from "../../icons";
 import {useResize} from "@edgedb/common/hooks/useResize";
+import {settingsState} from "../../state/settings";
 
 export const ReplView = observer(function ReplView() {
   const dbState = useDatabaseState();
@@ -162,9 +163,9 @@ const QueryOptions = observer(function QueryOptions() {
         <label>
           <input
             type="checkbox"
-            checked={replState.disableAccessPolicies}
+            checked={settingsState.disableAccessPolicies}
             onChange={(e) => {
-              replState.setDisableAccessPolicies(e.target.checked);
+              settingsState.setDisableAccessPolicies(e.target.checked);
             }}
           />
           Disable Access Policies
@@ -172,9 +173,9 @@ const QueryOptions = observer(function QueryOptions() {
         <label>
           <input
             type="checkbox"
-            checked={replState.persistQuery}
+            checked={settingsState.persistQuery}
             onChange={(e) => {
-              replState.setPersistQuery(e.target.checked);
+              settingsState.setPersistQuery(e.target.checked);
             }}
           />
           Persist Query

--- a/shared/studio/tabs/repl/replHistoryCell/index.tsx
+++ b/shared/studio/tabs/repl/replHistoryCell/index.tsx
@@ -65,7 +65,7 @@ export default observer(function ReplHistoryCell({
                     ) : null}
                   </div>
                 ) : null}
-                <div className={styles.info}>
+                {/* <div className={styles.info}>
                   {cell instanceof ReplResultCell && cell._result ? (
                     <CopyButton
                       label="Copy as JSON"
@@ -73,9 +73,9 @@ export default observer(function ReplHistoryCell({
                     />
                   ) : null}
                   <div className={styles.infoLabel}>
-                    {/*<ReplQueryDuration duration={cell.duration} />*/}
+                    <ReplQueryDuration duration={cell.duration} />
                   </div>
-                </div>
+                </div> */}
               </div>
 
               {cell instanceof ReplResultCell ? (

--- a/shared/studio/tabs/repl/replHistoryCell/replHistoryCell.module.scss
+++ b/shared/studio/tabs/repl/replHistoryCell/replHistoryCell.module.scss
@@ -85,6 +85,7 @@
 .outputBlock {
   grid-area: output;
   background-color: var(--repl-history-output-background);
+  min-width: 0;
 }
 
 .collapse {
@@ -180,12 +181,18 @@
 }
 
 .inspector {
-  margin: -6px 0 12px 12px !important;
+  margin: -6px 0 0 0 !important;
   width: calc(100% - 12px) !important;
   font-family: Roboto Mono;
   color: var(--repl-inspector-colour);
 
   @include customScrollbar;
+
+  --inspectorRowHoverBg: #e8e8e8;
+
+  @include darkTheme {
+    --inspectorRowHoverBg: #363636;
+  }
 }
 
 .queryStatus {

--- a/shared/studio/tabs/repl/state/index.ts
+++ b/shared/studio/tabs/repl/state/index.ts
@@ -37,6 +37,7 @@ import {
 import {dbCtx} from "../../../state";
 import {connCtx} from "../../../state/connection";
 import {instanceCtx} from "../../../state/instance";
+import {settingsState} from "../../../state/settings";
 
 import {SplitViewState} from "@edgedb/common/ui/splitView/model";
 import {
@@ -119,8 +120,6 @@ export class Repl extends Model({
   queryHistory: prop<ReplHistoryCell[]>(() => []),
 
   splitView: prop(() => new SplitViewState({})),
-  persistQuery: prop<boolean>(false).withSetter(),
-  disableAccessPolicies: prop<boolean>(false).withSetter(),
 
   historyScrollPos: prop<number>(0).withSetter(),
 }) {
@@ -258,7 +257,7 @@ export class Repl extends Model({
             query,
             paramsData ? serialiseParamsData(paramsData) : undefined,
             false,
-            this.disableAccessPolicies
+            settingsState.disableAccessPolicies
           )
         );
 
@@ -312,7 +311,7 @@ export class Repl extends Model({
       allCapabilities |= capabilities;
     }
 
-    if (success && !this.persistQuery) {
+    if (success && !settingsState.persistQuery) {
       this.currentQuery = Text.empty;
       this.queryParamsEditor.clear();
       this.historyCursor = -1;

--- a/shared/studio/tabs/repl/state/index.ts
+++ b/shared/studio/tabs/repl/state/index.ts
@@ -18,6 +18,7 @@ import {
 import {Text} from "@codemirror/state";
 
 import {InspectorState, resultGetterCtx} from "@edgedb/inspector/v2/state";
+import {renderResultAsJson} from "@edgedb/inspector/v2/renderJsonResult";
 
 // import {
 //   storeReplResult,
@@ -32,7 +33,6 @@ import {
   ErrorDetails,
   extractErrorDetails,
 } from "../../../utils/extractErrorDetails";
-import {renderResultAsJson} from "../../../utils/renderJsonResult";
 
 import {dbCtx} from "../../../state";
 import {connCtx} from "../../../state/connection";


### PR DESCRIPTION
Cherry picks following changes from repl redesign to 2.x:
- Add basic autocomplete support for `insert`, `update` and `delete`
- Allow selectively copying results from result inspector
- Save repl settings ('disable access policies', 'persist query') to localstorage
- Fix nested data loading in dataview when link is single (#68)