### PR TITLE
Lazy load truncated string data when opening edit popup in data view

### DIFF
--- a/shared/inspector/buildScalar.tsx
+++ b/shared/inspector/buildScalar.tsx
@@ -62,7 +62,8 @@ export function renderValue(
   isEnum: boolean,
   rangeKnownTypeName?: string,
   showTypeTag: boolean = true,
-  overrideStyles: {[key: string]: string} = {}
+  overrideStyles: {[key: string]: string} = {},
+  implicitLength?: number
 ): {body: JSX.Element; height?: number} {
   if (value == null) {
     return {body: <span className={styles.scalar_empty}>{"{}"}</span>};
@@ -148,7 +149,12 @@ export function renderValue(
     case "std::str": {
       const str = strToString(value);
       return {
-        body: <span className={styles.scalar_string}>{str}</span>,
+        body: (
+          <span className={styles.scalar_string}>
+            {str}
+            {implicitLength && value.length === implicitLength ? "…" : ""}
+          </span>
+        ),
         height: str.split("\n").length,
       };
     }

--- a/shared/studio/tabs/dataview/dataInspector.module.scss
+++ b/shared/studio/tabs/dataview/dataInspector.module.scss
@@ -402,6 +402,13 @@
   color: #747474;
 }
 
+.fetchingDataPlaceholder {
+  line-height: 32px;
+  padding: 0 12px;
+  font-style: italic;
+  opacity: 0.8;
+}
+
 .stickyCol {
   position: relative;
   height: 0px;

--- a/shared/studio/tabs/dataview/state/index.ts
+++ b/shared/studio/tabs/dataview/state/index.ts
@@ -1,4 +1,12 @@
-import {computed, observable, action, when, reaction, autorun} from "mobx";
+import {
+  computed,
+  observable,
+  action,
+  when,
+  reaction,
+  autorun,
+  runInAction,
+} from "mobx";
 import {
   model,
   Model,
@@ -722,6 +730,20 @@ export class DataInspector extends Model({
   @observable.ref
   dataFetchingError: Error | null = null;
 
+  @observable.shallow
+  fullyFetchedData = new Map<string, any>();
+
+  async fetchFullCellData(dataId: string, field: ObjectField) {
+    const query = `select (select ${this._getObjectTypeQuery} filter .id = <uuid>$id).${field.escapedName}`;
+    const conn = connCtx.get(this)!;
+
+    const val = (await conn.query(query, {id: dataId})).result![0];
+
+    runInAction(() => {
+      this.fullyFetchedData.set(`${dataId}__${field.name}`, val);
+    });
+  }
+
   @modelFlow
   _fetchData = _async(function* (this: DataInspector) {
     const offset = this._pendingOffsets[0];
@@ -840,6 +862,7 @@ export class DataInspector extends Model({
     this.expandedRows = [];
     this.gridRef?.resetAfterRowIndex(0);
     this._pendingOffsets = [...this.visibleOffsets];
+    this.fullyFetchedData.clear();
 
     if (this.fetchingData) {
       this.discardLastFetch = true;


### PR DESCRIPTION
Fixes #81

Truncating strings to 100 characters is done as an optimisation, so the data explorer doesn't load huge strings that mostly won't be seen in the ui. I overlooked that the ui needs to fetch the full string when editing, so now the full string is lazily fetched when the data editor is opened. Also strings that have been truncated are now indicated with `...`.