### PR TITLE
Fix collapsing/expanding inspector items when child items are multiline

### DIFF
--- a/shared/inspector/v2/index.tsx
+++ b/shared/inspector/v2/index.tsx
@@ -15,6 +15,7 @@ import {
   HTMLAttributes,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from "react";
 
@@ -95,8 +96,15 @@ const RowList = observer(function RowList({
       }
     }
 
+    const listRef = useRef<List>(null);
+
+    useEffect(() => {
+      state.listRef = listRef.current;
+    }, []);
+
     return (
       <List<Item[]>
+        ref={listRef}
         className={cn(styles.inspector, className, {
           [styles.jsonMode]: state._jsonMode,
         })}

--- a/shared/inspector/v2/state.ts
+++ b/shared/inspector/v2/state.ts
@@ -14,6 +14,7 @@ import {
 import {action, observable} from "mobx";
 import {_ICodec} from "edgedb";
 import {Item, buildItem, expandItem, ItemType} from "./buildItem";
+import type {VariableSizeList as List} from "react-window";
 
 export type {Item};
 
@@ -58,6 +59,8 @@ export class InspectorState extends Model({
   }
 
   loadNestedData: NestedDataGetter | null = null;
+
+  listRef: List | null = null;
 
   getItems() {
     if (!this._items.length) {
@@ -136,6 +139,8 @@ export class InspectorState extends Model({
       this
     );
     this._items.splice(index + 1, 0, ...expandedItems);
+
+    this.listRef?.resetAfterIndex(index);
   }
 
   @modelAction
@@ -153,5 +158,7 @@ export class InspectorState extends Model({
         this._items.splice(index + 1, itemEndIndex - index);
       }
     }
+
+    this.listRef?.resetAfterIndex(index);
   }
 }


### PR DESCRIPTION
Fixes #103 