### PR TITLE
Fix bug preventing data explorer inserts when type has required computed link

### DIFF
--- a/shared/studio/tabs/dataview/state/edits.ts
+++ b/shared/studio/tabs/dataview/state/edits.ts
@@ -432,9 +432,12 @@ export class DataEditingManager extends Model({}) {
             !prop.expr &&
             insertEdit.data[prop.name] == null
         ),
-
         ...Object.values(type.links).filter(
-          (link) => link.required && !link.default && !setLinks.has(link.name)
+          (link) =>
+            link.required &&
+            !link.default &&
+            !link.expr &&
+            !setLinks.has(link.name)
         ),
       ];
 


### PR DESCRIPTION
Reported on discord: https://discord.com/channels/841451783728529451/841451783728529454/1054401499402350632