### PR TITLE
Update separators icons to be smaller and tinier

### DIFF
--- a/shared/studio/components/headerTabs/index.tsx
+++ b/shared/studio/components/headerTabs/index.tsx
@@ -68,18 +68,16 @@ export function HeaderTabs({className}: HeaderTabsProps) {
 export function TabSep() {
   return (
     <svg
-      width="16"
-      height="24"
-      viewBox="0 0 16 30"
+      width="8"
+      height="17"
+      viewBox="0 0 8 17"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={styles.tabSep}
     >
       <path
-        d="M 1,29 L 15,1"
-        stroke="currentColor"
-        strokeWidth={1.5}
-        strokeLinecap="round"
+        d="M7.66602 0.78125L1.73828 16.2207H0.185547L6.12305 0.78125H7.66602Z"
+        fill="currentColor"
       />
     </svg>
   );


### PR DESCRIPTION
Depends on [102](https://github.com/edgedb/edgedb-ui/issues/102).

The designs for this [Figma](https://www.figma.com/file/430gInXr2xbFqBOLTCmpHJ/Cloud_UI?node-id=1345%3A42275&t=EcpPdCxBEr31DTZG-0).

Here is the fix for the first check point: separators.
The fix is ​​inside the shared folder which is also used for the website application as far as I know.

<img width="864" alt="Screenshot 2023-01-19 at 18 26 53" src="https://user-images.githubusercontent.com/18357201/213518509-2ee46c14-38ec-491b-a769-048b0133278b.png">
