### PR TITLE
Add button for query editor on the dashboard.

### DIFF
--- a/shared/studio/tabs/dashboard/databaseDashboard.module.scss
+++ b/shared/studio/tabs/dashboard/databaseDashboard.module.scss
@@ -63,16 +63,23 @@
 
   .button.button {
     margin: 4px;
+    width: 228px;
 
     & > div {
-      padding: 25px 42px;
-      border-radius: 8px;
+      padding: 24px 34px;
+      border-radius: 4px;
+      justify-content: center;
     }
 
     svg {
       fill: currentColor;
+      margin-right: 12px;
       width: 24px;
       height: 24px;
+    }
+
+    span {
+      margin: unset;
     }
   }
 

--- a/shared/studio/tabs/dashboard/index.tsx
+++ b/shared/studio/tabs/dashboard/index.tsx
@@ -78,7 +78,7 @@ export const DatabaseDashboard = observer(function DatabaseDashboard() {
 
             <Button
               className={styles.button}
-              label="Browse Schema"
+              label="Schema Viewer"
               size="large"
               icon={<TabSchemaIcon />}
               leftIcon
@@ -87,7 +87,7 @@ export const DatabaseDashboard = observer(function DatabaseDashboard() {
 
             <Button
               className={styles.button}
-              label="Browse Data"
+              label="Data Viewer"
               size="large"
               icon={<TabDataExplorerIcon />}
               leftIcon

--- a/shared/studio/tabs/dashboard/index.tsx
+++ b/shared/studio/tabs/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from "react";
+import {useEffect} from "react";
 import {observer} from "mobx-react-lite";
 import {useNavigate} from "react-router-dom";
 
@@ -24,6 +24,7 @@ import {
   TabDataExplorerIcon,
   TabReplIcon,
   TabSchemaIcon,
+  TabEditorIcon,
 } from "../../icons";
 
 export const DatabaseDashboard = observer(function DatabaseDashboard() {
@@ -64,6 +65,15 @@ export const DatabaseDashboard = observer(function DatabaseDashboard() {
               icon={<TabReplIcon />}
               leftIcon
               onClick={() => navigate("repl")}
+            ></Button>
+
+            <Button
+              className={styles.button}
+              label="Open Editor"
+              size="large"
+              icon={<TabEditorIcon />}
+              leftIcon
+              onClick={() => navigate("editor")}
             ></Button>
 
             <Button


### PR DESCRIPTION
Depends on [102](https://github.com/edgedb/edgedb-ui/issues/102).

Query editor button is added on the dashboard.
On desktop it looks fine, but on smaller screens 4 buttons aren't nicely organised.

<img width="1680" alt="Screenshot 2023-01-20 at 13 02 44" src="https://user-images.githubusercontent.com/18357201/213691119-77b09348-175f-4fae-9bef-f4ad46c1c189.png">
<img width="1680" alt="Screenshot 2023-01-20 at 13 02 37" src="https://user-images.githubusercontent.com/18357201/213691125-98b94f56-2e50-459f-a1e0-9af397f2e825.png">