### PR TITLE
130: Add different color for dropdown item labels.

### DIFF
--- a/shared/common/ui/select/select.module.scss
+++ b/shared/common/ui/select/select.module.scss
@@ -77,6 +77,7 @@
   min-width: 100%;
   cursor: pointer;
   padding-right: 32px;
+  color: var(--dropdown-item-color, inherit);
 
   &:hover {
     background: var(--app-accent-green);

--- a/shared/studio/components/headerTabs/headerTab.module.scss
+++ b/shared/studio/components/headerTabs/headerTab.module.scss
@@ -12,6 +12,8 @@
   color: var(--font-inactive-gray);
   font-weight: 600;
   padding: 6px 10px;
+  --dropdown-item-color: var(--font-active-gray);
+
   & > svg {
     fill: var(--font-inactive-gray);
     margin-right: 8px;

--- a/web/src/app.module.scss
+++ b/web/src/app.module.scss
@@ -64,11 +64,9 @@
   --font-active-gray: #666666;
 
   // Buttons
-  --btn-text-color: #4c4c4c;
-  --btn-green: #0ccb93;
   --btn-text-color: #333333;
+  --btn-green: #0ccb93;
   --btn-text-hover: #fafafa;
-
   --cursor-color: #808080;
 
   @include darkTheme {


### PR DESCRIPTION
Depends on [130](   git push --set-upstream origin 130-fix-topbar-dropdown-color).

<img width="280" alt="Screenshot 2023-02-08 at 22 10 18" src="https://user-images.githubusercontent.com/18357201/217651810-9dc9a4b7-43e0-40e9-8f47-cde99b6faf83.png">
<img width="328" alt="Screenshot 2023-02-08 at 22 10 15" src="https://user-images.githubusercontent.com/18357201/217651813-00002e71-73c6-4cac-ae5c-dff23819e457.png">