### PR TITLE
Schema fixes

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install EdgeDB
         uses: edgedb/setup-edgedb@v1
         with:
-          server-version: stable
+          server-version: 3.0-rc.1
 
       - name: Set up chrome
         uses: browser-actions/setup-chrome@v1

--- a/shared/studio/idbStore/index.ts
+++ b/shared/studio/idbStore/index.ts
@@ -1,5 +1,5 @@
 import {openDB, DBSchema} from "idb";
-import {SchemaData} from "../state/database";
+import {StoredSchemaData} from "../state/database";
 import {StoredSessionStateData} from "../state/sessionState";
 
 export interface QueryHistoryItem {
@@ -45,7 +45,7 @@ interface IDBStore extends DBSchema {
   };
   schemaData: {
     key: string;
-    value: {instanceId: string; data: SchemaData};
+    value: {instanceId: string; data: StoredSchemaData};
     indexes: {
       byInstanceId: string;
     };
@@ -199,7 +199,7 @@ export async function fetchResultData(itemId: string) {
 export async function storeSchemaData(
   dbName: string,
   instanceId: string,
-  data: SchemaData
+  data: StoredSchemaData
 ) {
   await (
     await db

--- a/shared/studio/state/instance.ts
+++ b/shared/studio/state/instance.ts
@@ -1,5 +1,5 @@
 import {createContext, useContext} from "react";
-import {action, observable, runInAction, when} from "mobx";
+import {action, computed, observable, runInAction, when} from "mobx";
 import {
   Model,
   model,
@@ -27,6 +27,7 @@ export const instanceCtx = createMobxContext<InstanceState>();
 
 @model("InstanceState")
 export class InstanceState extends Model({
+  _instanceId: prop<string | null>(null),
   serverUrl: prop<string>(),
   authUsername: prop<string | null>(null),
   authToken: prop<string | null>(),
@@ -36,6 +37,11 @@ export class InstanceState extends Model({
   @observable instanceName: string | null = null;
   @observable databases: string[] | null = null;
   @observable roles: string[] | null = null;
+
+  @computed
+  get instanceId() {
+    return this._instanceId ?? this.instanceName;
+  }
 
   defaultConnection: Connection | null = null;
 

--- a/shared/studio/tabs/schema/renderers/global.tsx
+++ b/shared/studio/tabs/schema/renderers/global.tsx
@@ -3,7 +3,6 @@ import {observer} from "mobx-react-lite";
 import {SchemaGlobal} from "@edgedb/common/schemaData";
 
 import {
-  Arrow,
   CollapseArrow,
   Copyable,
   CopyButton,
@@ -11,7 +10,6 @@ import {
   ItemHeader,
   Keyword,
   Punc,
-  Str,
   TypeLink,
   TypeName,
 } from "./utils";
@@ -53,8 +51,7 @@ export const GlobalRenderer = observer(function GlobalRenderer({
             <TypeName type={type} matches={matches} />
             {!type.expr ? (
               <>
-                {" "}
-                <Arrow />{" "}
+                <Punc>:</Punc>{" "}
                 <TypeLink type={type.target} parentModule={type.module} />
               </>
             ) : !hasBody ? (
@@ -111,11 +108,7 @@ export function globalToSDL(type: SchemaGlobal) {
   return `${type.required ? "required " : ""}${
     type.cardinality === "Many" ? "multi " : ""
   }global ${type.name}${
-    !type.expr
-      ? ` -> ${type.target.name}`
-      : !hasBody
-      ? ` := (${type.expr})`
-      : ""
+    !type.expr ? `: ${type.target.name}` : !hasBody ? ` := (${type.expr})` : ""
   }${
     hasBody
       ? `{\n${type.default ? `  default := (${type.default});\n` : ""}${

--- a/shared/studio/tabs/schema/renderers/module.tsx
+++ b/shared/studio/tabs/schema/renderers/module.tsx
@@ -6,7 +6,7 @@ import cn from "@edgedb/common/utils/classNames";
 import {SchemaModule, SchemaTextView} from "../state/textView";
 import {useSchemaTextState} from "../textView";
 
-import {Arrow, CollapseArrow, Keyword, Punc, Str} from "./utils";
+import {Keyword, Punc} from "./utils";
 
 import styles from "../textView.module.scss";
 

--- a/shared/studio/tabs/schema/renderers/pointer.tsx
+++ b/shared/studio/tabs/schema/renderers/pointer.tsx
@@ -15,7 +15,6 @@ import {
 import {SchemaModule, SearchMatches} from "../state/textView";
 
 import {
-  Arrow,
   CollapseArrow,
   Copyable,
   CopyButton,
@@ -159,8 +158,7 @@ export const PointerRenderer = observer(function _PointerRenderer({
               </>
             ) : (
               <>
-                {" "}
-                <Arrow />{" "}
+                <Punc>:</Punc>{" "}
                 <TypeLink type={pointer.target!} parentModule={parentModule} />
               </>
             )}
@@ -325,7 +323,7 @@ export function pointerToSDL(pointer: SchemaPointer): string {
       ? ""
       : pointer.expr && !hasBody
       ? ` := (${pointer.expr})`
-      : ` -> ${pointer.target!.name}`
+      : `: ${pointer.target!.name}`
   }${
     hasBody
       ? ` {\n${pointer.default ? `  default := (${pointer.default});\n` : ""}${

--- a/shared/studio/tabs/schema/renderers/utils.tsx
+++ b/shared/studio/tabs/schema/renderers/utils.tsx
@@ -153,7 +153,9 @@ export function TypeLink({
 
     return (
       <span
-        className={styles.typeLink}
+        className={cn(styles.typeLink, {
+          [styles.builtin]: type.schemaType === "Scalar" && type.builtin,
+        })}
         onClick={() => {
           goToItem(navigate, state, type);
         }}


### PR DESCRIPTION
The longstanding `TypeError: undefined is not an object (evaluating 'e.name.localeCompare')` bug (#188, #187, #79, #34), appears to be caused by some kind of data corruption that I think is possibly a bug in safari when cyclic data is stored in indexeddb. So I'm hoping that the refactor in this PR, to store the flat introspection data in indexeddb before we cross reference types in it, will fix this bug.

Also update schema introspection and rendering to support the new mutation rewrites, triggers and access policy `errmessage` in 3.0, and update from `->` to `:` syntax.