### PR TITLE
Update instancePage.module.scss

### DIFF
--- a/web/src/components/instancePage/instancePage.module.scss
+++ b/web/src/components/instancePage/instancePage.module.scss
@@ -53,6 +53,7 @@
 .databaseCard {
   background: var(--app-card-bg);
   border: 2px solid var(--app-card-bg);
+  word-break: break-all;
 
   span {
     font-weight: bold;


### PR DESCRIPTION
Add `word-break: break-all;` to `.databaseCard` element to fix issue of long database names not wrapping.

Before:
![2023-07-12_15-00](https://github.com/edgedb/edgedb-ui/assets/6868833/bb17127f-bb39-441b-9468-e3b9e3206223)

After:
![2023-07-12_15-00_1](https://github.com/edgedb/edgedb-ui/assets/6868833/1b4f8b48-6374-4341-ada8-6d8da8a066ea)

Note: i was unable to run the tests as the instructions in the readme didnt seem to work. It says to run `env EDGEDB_DEBUG_HTTP_INJECT_CORS=1 edgedb server --admin-ui=enabled`, but that errors, saying: `error: Found argument '--admin-ui' which wasn't expected, or isn't valid in this context
`