### PR TITLE
Update behaviour of datatable editor to save input by default on closing

### DIFF
--- a/shared/studio/components/dataEditor/dataEditor.module.scss
+++ b/shared/studio/components/dataEditor/dataEditor.module.scss
@@ -196,7 +196,7 @@
     display: block;
   }
 
-  .dataEditor > & {
+  .dataEditor > &:not(:last-child) {
     input,
     textarea {
       border-radius: 4px 0 0 4px;

--- a/shared/studio/components/dataEditor/editor.tsx
+++ b/shared/studio/components/dataEditor/editor.tsx
@@ -12,7 +12,7 @@ import {
   valueToEditorValue,
 } from "./utils";
 import {ArrayEditor, getInputComponent} from ".";
-import {EmptySetIcon, SubmitChangesIcon} from "../../icons";
+import {EmptySetIcon} from "../../icons";
 
 import styles from "./dataEditor.module.scss";
 import {observer} from "mobx-react-lite";

--- a/shared/studio/components/dataEditor/editor.tsx
+++ b/shared/studio/components/dataEditor/editor.tsx
@@ -1,0 +1,196 @@
+import {useEffect, useRef} from "react";
+import {action, makeObservable, observable} from "mobx";
+
+import cn from "@edgedb/common/utils/classNames";
+
+import {
+  EditorValue,
+  PrimitiveType,
+  isEditorValueValid,
+  newPrimitiveValue,
+  parseEditorValue,
+  valueToEditorValue,
+} from "./utils";
+import {ArrayEditor, getInputComponent} from ".";
+import {EmptySetIcon, SubmitChangesIcon} from "../../icons";
+
+import styles from "./dataEditor.module.scss";
+import {observer} from "mobx-react-lite";
+
+export type EditValue =
+  | {valid: true; value: any}
+  | {valid: false; value: EditorValue};
+
+export class DataEditorState {
+  constructor(
+    public readonly cellId: string,
+    public readonly type: PrimitiveType,
+    public readonly isRequired: boolean,
+    public readonly isMulti: boolean,
+    value: any,
+    isEditorValue: boolean,
+    public readonly onClose: (discard: boolean) => void
+  ) {
+    makeObservable(this);
+
+    if (isEditorValue) {
+      this.value = value;
+    } else {
+      this.value =
+        value != null
+          ? isMulti
+            ? value.map((val: any) => valueToEditorValue(val, type))
+            : valueToEditorValue(value, type)
+          : isRequired
+          ? isMulti
+            ? []
+            : newPrimitiveValue(type)[0]
+          : null;
+    }
+
+    this.hasError =
+      this.value === null
+        ? false
+        : isMulti
+        ? (this.value as EditorValue[]).some(
+            (v: any) => !isEditorValueValid(v, type)
+          )
+        : !isEditorValueValid(this.value, type);
+  }
+
+  isEdited = false;
+
+  @observable.ref value: EditorValue | null;
+  @action setValue(val: EditorValue | null) {
+    this.value = val;
+    this.isEdited = true;
+  }
+
+  @observable hasError: boolean;
+  @action setError(err: boolean) {
+    this.hasError = err;
+  }
+
+  getEditValue(): EditValue {
+    if (this.hasError) {
+      return {valid: false, value: this.value!};
+    } else {
+      return {valid: true, value: this._getParsedVal()};
+    }
+  }
+
+  private _getParsedVal() {
+    if (this.value == null) {
+      return null;
+    }
+    if (this.isMulti) {
+      return this.isRequired && !(this.value as EditorValue[]).length
+        ? null
+        : (this.value as EditorValue[]).map((v: any) =>
+            parseEditorValue(v, this.type)
+          );
+    } else {
+      const typename =
+        this.type.schemaType === "Scalar"
+          ? (this.type.knownBaseType ?? this.type).name
+          : null;
+      return !this.isRequired &&
+        typeof this.value === "string" &&
+        this.value.trim() === "" &&
+        !(typename === "std:str" || typename === "std::json")
+        ? null
+        : parseEditorValue(this.value, this.type);
+    }
+  }
+}
+
+export interface DataEditorProps {
+  state: DataEditorState;
+  style?: any;
+}
+
+export const DataEditor = observer(function DataEditor({
+  state,
+  style,
+}: DataEditorProps) {
+  const inputRef = useRef<HTMLElement>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus({preventScroll: true});
+    }
+    const clickListener = (e: MouseEvent) => {
+      if (!editorRef.current?.contains(e.target as Node)) {
+        state.onClose(false);
+      }
+    };
+    window.addEventListener("click", clickListener, {capture: true});
+
+    const keyListener = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        state.onClose(true);
+        return;
+      }
+      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        state.onClose(false);
+        return;
+      }
+    };
+    editorRef.current?.addEventListener("keydown", keyListener, {
+      capture: true,
+    });
+
+    return () => {
+      window.removeEventListener("click", clickListener, {capture: true});
+      editorRef.current?.removeEventListener("keydown", keyListener, {
+        capture: true,
+      });
+    };
+  }, []);
+
+  const Input = state.isMulti
+    ? ArrayEditor
+    : getInputComponent(state.type, !state.isRequired);
+
+  return (
+    <div
+      ref={editorRef}
+      className={cn(styles.dataEditor, {
+        [styles.showBackground]:
+          state.value === null &&
+          !state.isMulti &&
+          state.type.schemaType !== "Scalar",
+      })}
+      style={style}
+    >
+      <Input
+        ref={inputRef}
+        type={state.type as any}
+        isMulti={state.isMulti}
+        depth={0}
+        allowEmptyPrimitive={!state.isRequired}
+        value={(state.value ?? (state.isMulti ? [] : null)) as any}
+        onChange={(val: any, err: boolean) => {
+          state.setValue(val);
+          state.setError(err);
+        }}
+      />
+
+      {!state.isRequired ? (
+        <div className={styles.actions}>
+          <div
+            className={cn(styles.action, styles.emptySetAction)}
+            onClick={() => {
+              state.setValue(null);
+              state.setError(false);
+              state.onClose(false);
+            }}
+          >
+            <EmptySetIcon />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/shared/studio/components/dataEditor/index.tsx
+++ b/shared/studio/components/dataEditor/index.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, RefObject, useEffect, useRef, useState} from "react";
+import {forwardRef, RefObject, useEffect, useState} from "react";
 
 import cn from "@edgedb/common/utils/classNames";
 

--- a/shared/studio/tabs/dataview/dataInspector.module.scss
+++ b/shared/studio/tabs/dataview/dataInspector.module.scss
@@ -358,11 +358,21 @@
   }
 }
 
-.hasErrors:before {
-  border-color: #d78d87;
+.hasErrors {
+  .invalidValue {
+    color: #c44f45;
+  }
+  &:before {
+    border-color: #d78d87;
+  }
 
   @include darkTheme {
-    border-color: #af6963;
+    .invalidValue {
+      color: #e6776e;
+    }
+    &:before {
+      border-color: #af6963;
+    }
   }
 }
 

--- a/shared/studio/tabs/dataview/editsModal.module.scss
+++ b/shared/studio/tabs/dataview/editsModal.module.scss
@@ -90,6 +90,17 @@
   }
 }
 
+.codeBlockParamInvalid {
+  display: inline-flex;
+  background: rgba(222, 83, 83, 0.1);
+  color: #de5353;
+  line-height: 22px;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
 .greenButton {
   --buttonBg: var(--app-accent-green);
   --buttonTextColour: #fff;

--- a/shared/studio/tabs/dataview/reviewEditsModal.tsx
+++ b/shared/studio/tabs/dataview/reviewEditsModal.tsx
@@ -17,6 +17,11 @@ import {
   extractErrorDetails,
 } from "../../utils/extractErrorDetails";
 
+import {
+  PrimitiveType,
+  renderInvalidEditorValue,
+} from "../../components/dataEditor/utils";
+
 import {renderValue} from "@edgedb/inspector/buildScalar";
 import inspectorStyles from "@edgedb/inspector/inspector.module.scss";
 
@@ -88,11 +93,23 @@ export const ReviewEditsModal = observer(function ReviewEditsModal({
                     (node) => ({
                       range: [node.from, node.to],
                       renderer: (_, content) => {
-                        const paramName = code
+                        const [paramCast, paramName] = code
                           .slice(node.from, node.to)
-                          .split("$")[1];
+                          .split("$");
                         const param = params[paramName];
 
+                        if (paramCast === "<_invalid>") {
+                          return (
+                            <span className={styles.codeBlockParamInvalid}>
+                              {renderInvalidEditorValue(
+                                param.value,
+                                param.type as PrimitiveType
+                              )}
+                            </span>
+                          );
+                        }
+
+                        content.props.children.pop();
                         return (
                           <span className={styles.codeBlockParam}>
                             {content}

--- a/shared/studio/tabs/dataview/state/edits.ts
+++ b/shared/studio/tabs/dataview/state/edits.ts
@@ -15,7 +15,6 @@ import {PrimitiveType} from "../../../components/dataEditor";
 
 import {connCtx, dbCtx} from "../../../state";
 import {ObjectPropertyField} from ".";
-import {renderInvalidEditorValue} from "../../../components/dataEditor/utils";
 
 enum EditKind {
   UpdateProperty,

--- a/shared/studio/tabs/dataview/state/edits.ts
+++ b/shared/studio/tabs/dataview/state/edits.ts
@@ -7,8 +7,15 @@ import {
   escapeName,
   SchemaObjectType,
 } from "@edgedb/common/schemaData";
+import {
+  EditValue,
+  DataEditorState,
+} from "../../../components/dataEditor/editor";
+import {PrimitiveType} from "../../../components/dataEditor";
 
 import {connCtx, dbCtx} from "../../../state";
+import {ObjectPropertyField} from ".";
+import {renderInvalidEditorValue} from "../../../components/dataEditor/utils";
 
 enum EditKind {
   UpdateProperty,
@@ -23,7 +30,7 @@ interface UpdatePropertyEdit {
   objectTypeName: string;
   escapedObjectTypeName: string;
   fieldName: string;
-  value: any;
+  value: EditValue;
 }
 
 export enum UpdateLinkChangeKind {
@@ -56,7 +63,7 @@ interface InsertObjectEdit {
   id: number;
   objectTypeName: string;
   escapedObjectTypeName: string;
-  data: {[fieldName: string]: any};
+  data: {[fieldName: string]: string | number | EditValue | undefined};
 }
 
 interface DeleteObjectEdit {
@@ -74,7 +81,7 @@ export class DataEditingManager extends Model({}) {
   propertyEdits: Map<string, UpdatePropertyEdit> = new Map();
 
   @observable.ref
-  activePropertyEditId: string | null = null;
+  activePropertyEdit: DataEditorState | null = null;
 
   @observable
   linkEdits: Map<string, UpdateLinkEdit> = new Map();
@@ -96,18 +103,44 @@ export class DataEditingManager extends Model({}) {
   }
 
   @action
-  startEditingCell(objectId: string | number, fieldName: string) {
-    const cellId = `${objectId}__${fieldName}`;
+  startEditingCell(
+    objectId: string | number,
+    objectTypeName: string,
+    field: ObjectPropertyField,
+    value: any
+  ) {
+    const cellId = `${objectId}__${field.name}`;
 
-    this.activePropertyEditId = cellId;
+    const editValue = this.propertyEdits.get(cellId)?.value;
+
+    const state = new DataEditorState(
+      cellId,
+      field.schemaType as PrimitiveType,
+      field.required,
+      field.multi,
+      editValue?.value ?? value,
+      editValue != null && !editValue.valid,
+      (discard) => {
+        if (!discard && state.isEdited) {
+          this._updateCellEdit(
+            objectId,
+            objectTypeName,
+            field.name,
+            state.getEditValue()
+          );
+        }
+        this._finishEditingCell();
+      }
+    );
+    this.activePropertyEdit = state;
   }
 
   @action
-  updateCellEdit(
+  _updateCellEdit(
     objectId: string | number,
     objectTypeName: string,
     fieldName: string,
-    value: any
+    value: EditValue
   ) {
     if (typeof objectId === "string") {
       const cellId = `${objectId}__${fieldName}`;
@@ -129,15 +162,15 @@ export class DataEditingManager extends Model({}) {
   }
 
   @action
-  finishEditingCell() {
-    this.activePropertyEditId = null;
+  _finishEditingCell() {
+    this.activePropertyEdit = null;
   }
 
   @action
   clearPropertyEdit(objectId: string | number, fieldName: string) {
     const cellId = `${objectId}__${fieldName}`;
-    if (this.activePropertyEditId === cellId) {
-      this.activePropertyEditId = null;
+    if (this.activePropertyEdit?.cellId === cellId) {
+      this.activePropertyEdit = null;
     }
     if (typeof objectId === "string") {
       this.propertyEdits.delete(cellId);
@@ -326,7 +359,7 @@ export class DataEditingManager extends Model({}) {
   @action
   clearAllPendingEdits() {
     this.propertyEdits.clear();
-    this.activePropertyEditId = null;
+    this.activePropertyEdit = null;
     this.linkEdits.clear();
     this.insertEdits.clear();
     this.deleteEdits.clear();
@@ -369,7 +402,7 @@ export class DataEditingManager extends Model({}) {
     function generatePropUpdate(
       objectTypeName: string,
       propName: string,
-      val: any
+      val: EditValue
     ) {
       const type =
         schemaData.objectsByName.get(objectTypeName)?.properties[propName];
@@ -427,12 +460,18 @@ export class DataEditingManager extends Model({}) {
     for (const insertEdit of this.insertEdits.values()) {
       const fields: string[] = [];
       const deps: number[] = [];
+      let invalidFields: string[] = [];
 
       const type = schemaData.objectsByName.get(insertEdit.objectTypeName)!;
 
       for (const [key, val] of Object.entries(insertEdit.data)) {
         if (key === "id" || key === "__tname__") continue;
-        fields.push(generatePropUpdate(insertEdit.objectTypeName, key, val));
+        fields.push(
+          generatePropUpdate(insertEdit.objectTypeName, key, val as EditValue)
+        );
+        if ((val as EditValue).valid === false) {
+          invalidFields.push(key);
+        }
       }
 
       const linkEdits = insertLinkEdits.get(insertEdit.id) ?? [];
@@ -479,6 +518,8 @@ export class DataEditingManager extends Model({}) {
           ? `Values are missing for required fields: ${missingFields
               .map((field) => `'${field.name}'`)
               .join(", ")}`
+          : invalidFields.length
+          ? `Invalid input in fields: ${invalidFields.join(", ")}`
           : undefined,
       });
     }
@@ -493,6 +534,7 @@ export class DataEditingManager extends Model({}) {
     let updateCount = 1;
     for (const [objectId, edits] of updateEdits) {
       const editLines: string[] = [];
+      const invalidFields: string[] = [];
 
       const type = schemaData.objectsByName.get(edits.objectTypeName)!;
 
@@ -504,6 +546,9 @@ export class DataEditingManager extends Model({}) {
             propEdit.value
           )
         );
+        if (propEdit.value.valid === false) {
+          invalidFields.push(propEdit.fieldName);
+        }
       }
       for (const linkEdit of edits.links) {
         const linkUpdate = generateLinkUpdate(
@@ -525,6 +570,9 @@ filter .id = <uuid>'${objectId}'
 set {
   ${editLines.join(",\n  ")}
 }`,
+          error: invalidFields.length
+            ? `Invalid input in fields: ${invalidFields.join(", ")}`
+            : undefined,
         });
       }
     }
@@ -544,7 +592,7 @@ set {
   async commitPendingEdits() {
     const conn = connCtx.get(this)!;
 
-    this.activePropertyEditId = null;
+    this.activePropertyEdit = null;
 
     const {statements, params} = this.generateStatements();
     const query = generateQueryFromStatements(statements);
@@ -677,10 +725,18 @@ function generateLinkUpdate(
 
 function generateParamExpr(
   type: SchemaType,
-  data: any,
+  _data: EditValue,
   params: {[key: string]: {type: SchemaType; value: any}},
   multi?: boolean
 ): string {
+  if (!_data.valid) {
+    const paramName = `p${Object.keys(params).length}`;
+    params[paramName] = {type, value: _data.value};
+    return `<_invalid>$${paramName}`;
+  }
+
+  const data = _data.value;
+
   if (data === null) {
     return `<${getNameOfSchemaType(type)[1]}>{}`;
   }

--- a/shared/studio/tabs/dataview/state/index.ts
+++ b/shared/studio/tabs/dataview/state/index.ts
@@ -216,7 +216,7 @@ export enum ObjectFieldType {
   link,
 }
 
-export type ObjectField = {
+interface _BaseObjectField {
   subtypeName?: string;
   escapedSubtypeName?: string;
   name: string;
@@ -231,17 +231,19 @@ export type ObjectField = {
   readonly: boolean;
   multi: boolean;
   secret: boolean;
-} & (
-  | {
-      type: ObjectFieldType.property;
-      default: string | null;
-      schemaType: SchemaType;
-    }
-  | {
-      type: ObjectFieldType.link;
-      targetHasSelectAccessPolicy: boolean;
-    }
-);
+}
+
+export interface ObjectPropertyField extends _BaseObjectField {
+  type: ObjectFieldType.property;
+  default: string | null;
+  schemaType: SchemaType;
+}
+export interface ObjectLinkField extends _BaseObjectField {
+  type: ObjectFieldType.link;
+  targetHasSelectAccessPolicy: boolean;
+}
+
+export type ObjectField = ObjectPropertyField | ObjectLinkField;
 
 interface SortBy {
   fieldIndex: number;


### PR DESCRIPTION
Fixes #310

Input in datatable editor is now saved to pending edits by default when it closes (including clicking out of it), unless it's closed by the 'esc' key. This change also means invalid input can exist in the pending edits now, so styling added for invalid cells + checks added in commit changes modal.