### PR TITLE
Keep server port in base URL for redirect_uri

### DIFF
--- a/shared/studio/tabs/auth/index.tsx
+++ b/shared/studio/tabs/auth/index.tsx
@@ -142,9 +142,6 @@ const AuthUrls = observer(function AuthUrls({
   const databaseState = useDatabaseState();
 
   const url = new URL(instanceState.serverUrl);
-  if (url.hostname.endsWith(".edgedb.cloud")) {
-    url.port = "";
-  }
   url.pathname = `db/${databaseState.name}/ext/auth`;
 
   const baseUrl = url.toString();


### PR DESCRIPTION
Providers want an _exact_ match and we send the redirect_uri with the port when we make our authorize request to the IdP.

See https://github.com/edgedb/edgedb/blob/466120c00cc0165b02e06c9287e1dcb6cff6c79e/edb/server/protocol/protocol.pyx#L665-L669