### PR TITLE
Update Auth preview form heading style

### DIFF
--- a/shared/studio/tabs/auth/loginuipreview.module.scss
+++ b/shared/studio/tabs/auth/loginuipreview.module.scss
@@ -61,8 +61,10 @@
     color: #495057;
     font-size: 22px;
     font-style: normal;
+    line-height: normal;
     font-weight: 550;
     margin-bottom: 20px;
+    
   }
   form h1 span {
     opacity: 0.7;

--- a/shared/studio/tabs/auth/loginuipreview.module.scss
+++ b/shared/studio/tabs/auth/loginuipreview.module.scss
@@ -64,7 +64,6 @@
     line-height: normal;
     font-weight: 550;
     margin-bottom: 20px;
-    
   }
   form h1 span {
     opacity: 0.7;


### PR DESCRIPTION
Small fix for the Auth preview UI heading.

Before:
<img width="482" alt="Screenshot 2024-10-11 at 14 07 01" src="https://github.com/user-attachments/assets/74563da8-2aac-4724-a118-4e3ad3d5895b">
After:
<img width="499" alt="Screenshot 2024-10-11 at 14 06 51" src="https://github.com/user-attachments/assets/946adc38-5e43-45d8-929e-ed382fcb1d6f">

(FWIW, I realise that two lines of the app name is not ideal anyway, and rather a rare scenario, but I figured it's still worth fixing.) 