### PR TITLE
Add support for new SMTP config schema

### DIFF
--- a/shared/studio/tabs/auth/authAdmin.module.scss
+++ b/shared/studio/tabs/auth/authAdmin.module.scss
@@ -120,6 +120,20 @@
   }
 }
 
+.titleWrapper {
+  display: flex;
+  align-items: center;
+  min-height: 36px;
+
+  h2 {
+    margin-right: 24px;
+  }
+
+  button {
+    margin-left: auto;
+  }
+}
+
 .cardList {
   display: flex;
   flex-direction: column;
@@ -543,7 +557,6 @@
     &.selected {
       fill: #a565cd;
       stroke: #9c56b4 !important;
-      pointer-events: none;
     }
 
     @include darkTheme {

--- a/shared/studio/tabs/auth/authAdmin.module.scss
+++ b/shared/studio/tabs/auth/authAdmin.module.scss
@@ -475,6 +475,141 @@
   resize: vertical;
 }
 
+.newDraftSMTPProvider {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  .configGrid {
+    margin-top: 0;
+  }
+
+  .buttons {
+    display: flex;
+    gap: 16px;
+    justify-content: flex-end;
+    margin-top: 24px;
+    flex-direction: row;
+  }
+}
+
+.emailProvidersUpdating {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.emailProviderCard {
+  .details {
+    display: flex;
+    flex-direction: column;
+    color: var(--main_text_color);
+    line-height: 22px;
+
+    .name {
+      font-weight: 500;
+    }
+
+    .senderhost {
+      color: var(--tertiary_text_color);
+
+      span {
+        font-size: 11px;
+        margin: 0 6px;
+        opacity: 0.5;
+      }
+    }
+  }
+
+  .selectCurrentProvider {
+    width: 32px;
+    height: 32px;
+    stroke-width: 1px;
+    stroke: var(--Grey75);
+    cursor: pointer;
+    flex-shrink: 0;
+
+    &.selected {
+      fill: #a565cd;
+      stroke: #9c56b4 !important;
+      pointer-events: none;
+    }
+
+    @include darkTheme {
+      stroke: var(--Grey40);
+    }
+  }
+
+  .updatingSpinner {
+    color: var(--Grey50);
+    width: 32px;
+    flex-shrink: 0;
+  }
+
+  .buttons {
+    display: flex;
+    gap: 16px;
+    justify-content: flex-end;
+    flex-direction: row;
+    padding: 4px 16px 16px 16px;
+  }
+}
+
+.expandedEmailProviderConfig {
+  margin: -2px 12px 12px 12px;
+  background: var(--Grey97);
+  border-radius: 8px;
+  border: 1px solid var(--Grey93);
+
+  @include darkTheme {
+    background: var(--Grey16);
+    border-color: var(--Grey25);
+  }
+
+  .configGrid {
+    margin-top: 20px;
+    margin-bottom: 12px;
+
+    @include isMobile {
+      margin: 16px;
+    }
+  }
+}
+
+.emailProviderWarning {
+  position: relative;
+  padding: 16px 20px;
+  padding-left: 48px;
+  background: #f7e9c8;
+  border-radius: 8px;
+  border: 1px solid #c1a970;
+  color: #7b6226;
+  font-weight: 450;
+  line-height: 20px;
+  margin-top: 16px;
+
+  & > svg {
+    position: absolute;
+    left: 16px;
+    top: 14px;
+  }
+
+  & > span {
+    font-weight: 500;
+  }
+
+  .link {
+    font-weight: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  @include darkTheme {
+    background: #453d2c;
+    border: 1px solid #72623b;
+    color: #d1bd8f;
+  }
+}
+
 .docsNote {
   display: flex;
   align-items: flex-start;

--- a/shared/studio/tabs/auth/authAdmin.module.scss
+++ b/shared/studio/tabs/auth/authAdmin.module.scss
@@ -581,14 +581,14 @@
 
 .expandedEmailProviderConfig {
   margin: -2px 12px 12px 12px;
-  // background: var(--Grey97);
+  background: var(--Grey97);
   border-radius: 8px;
-  // border: 1px solid var(--Grey93);
+  border: 1px solid var(--Grey93);
 
-  // @include darkTheme {
-  //   background: var(--Grey16);
-  //   border-color: var(--Grey25);
-  // }
+  @include darkTheme {
+    background: var(--Grey16);
+    border-color: var(--Grey25);
+  }
 
   .configGrid {
     margin-top: 20px;
@@ -600,9 +600,46 @@
   }
 }
 
+.passwordWarning {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  color: var(--secondary_text_color);
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
+  background: #f7e9c8;
+  border-radius: 8px;
+  border: 1px solid #c1a970;
+  color: #7b6226;
+  padding: 8px 12px 10px 12px;
+  margin: 0 12px;
+  margin-bottom: 0px;
+  margin-bottom: 12px;
+
+  > div {
+    margin-top: 2px;
+
+    > span {
+      font-weight: 500;
+    }
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  @include darkTheme {
+    background: #453d2c;
+    border: 1px solid #72623b;
+    color: #d1bd8f;
+  }
+}
+
 .emailProviderWarning {
   position: relative;
-  padding: 16px 20px;
+  padding: 12px 20px;
   padding-left: 48px;
   background: #f7e9c8;
   border-radius: 8px;

--- a/shared/studio/tabs/auth/authAdmin.module.scss
+++ b/shared/studio/tabs/auth/authAdmin.module.scss
@@ -457,6 +457,18 @@
 
 .securitySelect {
   font-family: "Roboto Mono Variable", monospace;
+
+  &[data-disabled="true"] {
+    background: #f7f7f7;
+    border-color: var(--Grey90);
+    box-shadow: none;
+    opacity: 1;
+
+    @include darkTheme {
+      background: #464646;
+      border-color: #4d4d4d;
+    }
+  }
 }
 
 .redirectUrlsLabel {
@@ -556,14 +568,14 @@
 
 .expandedEmailProviderConfig {
   margin: -2px 12px 12px 12px;
-  background: var(--Grey97);
+  // background: var(--Grey97);
   border-radius: 8px;
-  border: 1px solid var(--Grey93);
+  // border: 1px solid var(--Grey93);
 
-  @include darkTheme {
-    background: var(--Grey16);
-    border-color: var(--Grey25);
-  }
+  // @include darkTheme {
+  //   background: var(--Grey16);
+  //   border-color: var(--Grey25);
+  // }
 
   .configGrid {
     margin-top: 20px;

--- a/shared/studio/tabs/auth/authAdmin.module.scss
+++ b/shared/studio/tabs/auth/authAdmin.module.scss
@@ -255,19 +255,32 @@
 
   .grid {
     display: grid;
-    grid-auto-flow: column;
-    grid-template-rows: repeat(calc(var(--itemCount) / var(--colCount)), auto);
-    gap: 4px;
+    grid-template-columns: repeat(var(--colCount), auto);
+    gap: 6px 24px;
+
+    > div {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
 
     label {
       font-family: "Roboto Mono Variable", monospace;
       font-weight: 425;
       font-size: 13px;
+      align-items: start;
+      height: auto;
+      line-height: 20px;
+      padding: 6px 0;
     }
   }
 
   @media (max-width: 960px) {
     --colCount: 2;
+
+    .grid > div:nth-child(2) {
+      grid-row: span 2;
+    }
   }
   @media (max-width: 512px) {
     --colCount: 1;

--- a/shared/studio/tabs/auth/providers.tsx
+++ b/shared/studio/tabs/auth/providers.tsx
@@ -54,14 +54,22 @@ export const ProvidersTab = observer(function ProvidersTab() {
               {state.emailProviderWarnings.verificationNoSmtp ? (
                 <EmailProviderWarning>
                   You have auth providers requiring email verification enabled,
-                  but no SMTP provider is configured.
+                  but no method for verifying emails is configured.
                   <br />
                   <span
                     className={styles.link}
                     onClick={() => state.setSelectedTab("smtp")}
                   >
                     Enable an SMTP provider
-                  </span>
+                  </span>{" "}
+                  or{" "}
+                  <span
+                    className={styles.link}
+                    onClick={() => state.setSelectedTab("webhooks")}
+                  >
+                    create a webhook
+                  </span>{" "}
+                  to handle email verification.
                 </EmailProviderWarning>
               ) : state.emailProviderWarnings.passwordNoReset ? (
                 <EmailProviderWarning>

--- a/shared/studio/tabs/auth/providers.tsx
+++ b/shared/studio/tabs/auth/providers.tsx
@@ -32,7 +32,7 @@ import {
 } from "@edgedb/common/newui";
 
 import styles from "./authAdmin.module.scss";
-import {StickyBottomBar} from "./shared";
+import {EmailProviderWarning, StickyBottomBar} from "./shared";
 import {Theme, useTheme} from "@edgedb/common/hooks/useTheme";
 import {AppConfigForm} from "./config";
 import {
@@ -52,11 +52,10 @@ export const ProvidersTab = observer(function ProvidersTab() {
         <>
           {state.providers.length ? (
             <>
-              {state.noEmailProviderWarning ? (
-                <div className={styles.emailProviderWarning}>
-                  <WarningIcon />
-                  <span>Warning:</span> You have enabled auth providers
-                  requiring email, but no SMTP provider is configured.
+              {state.emailProviderWarnings.verificationNoSmtp ? (
+                <EmailProviderWarning>
+                  You have auth providers requiring email verification enabled,
+                  but no SMTP provider is configured.
                   <br />
                   <span
                     className={styles.link}
@@ -64,7 +63,47 @@ export const ProvidersTab = observer(function ProvidersTab() {
                   >
                     Enable an SMTP provider
                   </span>
-                </div>
+                </EmailProviderWarning>
+              ) : state.emailProviderWarnings.passwordNoReset ? (
+                <EmailProviderWarning>
+                  You have the 'Email + Password' auth provider enabled, but no
+                  method for sending password resets is configured.
+                  <br />
+                  <span
+                    className={styles.link}
+                    onClick={() => state.setSelectedTab("smtp")}
+                  >
+                    Enable an SMTP provider
+                  </span>{" "}
+                  or{" "}
+                  <span
+                    className={styles.link}
+                    onClick={() => state.setSelectedTab("webhooks")}
+                  >
+                    create a webhook
+                  </span>{" "}
+                  to handle password resets.
+                </EmailProviderWarning>
+              ) : state.emailProviderWarnings.magicLinkNoMethods ? (
+                <EmailProviderWarning>
+                  You have the 'Magic Link' auth provider enabled, but no
+                  method for sending magic links is configured.
+                  <br />
+                  <span
+                    className={styles.link}
+                    onClick={() => state.setSelectedTab("smtp")}
+                  >
+                    Enable an SMTP provider
+                  </span>{" "}
+                  or{" "}
+                  <span
+                    className={styles.link}
+                    onClick={() => state.setSelectedTab("webhooks")}
+                  >
+                    create a webhook
+                  </span>{" "}
+                  to handle magic links.
+                </EmailProviderWarning>
               ) : null}
 
               <div className={styles.cardList}>

--- a/shared/studio/tabs/auth/providers.tsx
+++ b/shared/studio/tabs/auth/providers.tsx
@@ -28,7 +28,6 @@ import {
   Select,
   SelectItem,
   TextInput,
-  WarningIcon,
 } from "@edgedb/common/newui";
 
 import styles from "./authAdmin.module.scss";

--- a/shared/studio/tabs/auth/providers.tsx
+++ b/shared/studio/tabs/auth/providers.tsx
@@ -28,6 +28,7 @@ import {
   Select,
   SelectItem,
   TextInput,
+  WarningIcon,
 } from "@edgedb/common/newui";
 
 import styles from "./authAdmin.module.scss";
@@ -50,11 +51,28 @@ export const ProvidersTab = observer(function ProvidersTab() {
       {state.providers ? (
         <>
           {state.providers.length ? (
-            <div className={styles.cardList}>
-              {state.providers.map((provider) => (
-                <ProviderCard key={provider.name} provider={provider} />
-              ))}
-            </div>
+            <>
+              {state.noEmailProviderWarning ? (
+                <div className={styles.emailProviderWarning}>
+                  <WarningIcon />
+                  <span>Warning:</span> You have enabled auth providers
+                  requiring email, but no SMTP provider is configured.
+                  <br />
+                  <span
+                    className={styles.link}
+                    onClick={() => state.setSelectedTab("smtp")}
+                  >
+                    Enable an SMTP provider
+                  </span>
+                </div>
+              ) : null}
+
+              <div className={styles.cardList}>
+                {state.providers.map((provider) => (
+                  <ProviderCard key={provider.name} provider={provider} />
+                ))}
+              </div>
+            </>
           ) : null}
 
           {state.draftProviderConfig ? (

--- a/shared/studio/tabs/auth/shared.tsx
+++ b/shared/studio/tabs/auth/shared.tsx
@@ -2,7 +2,7 @@ import {observer} from "mobx-react-lite";
 
 import cn from "@edgedb/common/utils/classNames";
 
-import {Button} from "@edgedb/common/newui";
+import {Button, WarningIcon} from "@edgedb/common/newui";
 
 import {AbstractDraftConfig} from "./state";
 
@@ -53,3 +53,12 @@ export const StickyFormControls = observer(function StickyFormControls({
 export const InputSkeleton = () => (
   <LoadingSkeleton className={styles.inputSkeleton} />
 );
+
+export function EmailProviderWarning({children}: PropsWithChildren<{}>) {
+  return (
+    <div className={styles.emailProviderWarning}>
+      <WarningIcon />
+      <span>Warning:</span> {children}
+    </div>
+  );
+}

--- a/shared/studio/tabs/auth/smtp.tsx
+++ b/shared/studio/tabs/auth/smtp.tsx
@@ -191,18 +191,26 @@ const EmailProviderCard = observer(function EmailProviderCard({
       {draftState?.expanded ? (
         <>
           <div className={styles.expandedEmailProviderConfig}>
-            <SMTPConfigForm loaded hasName smtp={draftState} />
+            <SMTPConfigForm
+              smtp={draftState}
+              loaded
+              hasName
+              newProvider
+              readonly
+            />
           </div>
 
           <div className={styles.buttons}>
             <ConfirmButton
-              style={{marginRight: "auto"}}
               onClick={() => state.removeEmailProvider(provider.name)}
             >
               Remove
             </ConfirmButton>
 
-            {draftState.formChanged ? (
+            {/* Hide this for now since the config system doesn't have a good way
+            to update objects, other than delete+insert which loses the secret
+            password field (unless the user re-enters it) */}
+            {/* {draftState.formChanged ? (
               <Button
                 disabled={draftState.updating}
                 onClick={() => draftState.clearForm()}
@@ -217,7 +225,7 @@ const EmailProviderCard = observer(function EmailProviderCard({
               loading={draftState.updating}
             >
               {draftState.updating ? "Updating..." : "Update"}
-            </Button>
+            </Button> */}
           </div>
         </>
       ) : null}
@@ -263,11 +271,13 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
   newProvider,
   loaded,
   smtp,
+  readonly,
 }: {
   hasName?: boolean;
   newProvider?: boolean;
   loaded: boolean;
   smtp: DraftSMTPConfig;
+  readonly?: boolean;
 }) {
   const security = smtp.getConfigValue("security") as unknown as SMTPSecurity;
 
@@ -285,6 +295,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
                 value={smtp.getConfigValue("name")}
                 onChange={(e) => smtp.setConfigValue("name", e.target.value)}
                 error={smtp.nameError}
+                readOnly={readonly}
               />
             ) : (
               <InputSkeleton />
@@ -307,6 +318,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
               value={smtp.getConfigValue("sender")}
               onChange={(e) => smtp.setConfigValue("sender", e.target.value)}
               error={smtp.senderError}
+              readOnly={readonly}
             />
           ) : (
             <InputSkeleton />
@@ -328,6 +340,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
               value={smtp.getConfigValue("host")}
               onChange={(e) => smtp.setConfigValue("host", e.target.value)}
               placeholder="localhost"
+              readOnly={readonly}
             />
           ) : (
             <InputSkeleton />
@@ -359,6 +372,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
                   : "25"
               }
               error={smtp.portError}
+              readOnly={readonly}
               size={10}
             />
           ) : (
@@ -382,6 +396,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
             <TextInput
               value={smtp.getConfigValue("username")}
               onChange={(e) => smtp.setConfigValue("username", e.target.value)}
+              readOnly={readonly}
             />
           ) : (
             <InputSkeleton />
@@ -402,6 +417,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
             <TextInput
               value={smtp.getConfigValue("password")}
               onChange={(e) => smtp.setConfigValue("password", e.target.value)}
+              readOnly={readonly}
             />
           ) : (
             <InputSkeleton />
@@ -427,6 +443,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
               selectedItemId={smtp.getConfigValue("security") as any}
               onChange={(item) => smtp.setConfigValue("security", item.id)}
               items={smtpSecurity.map((val) => ({id: val, label: val}))}
+              disabled={readonly}
             />
           ) : (
             <InputSkeleton />
@@ -455,6 +472,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
               onChange={(checked) =>
                 smtp.setConfigValue("validate_certs", checked)
               }
+              readOnly={readonly}
             />
           ) : (
             <InputSkeleton />
@@ -481,6 +499,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
                 )
               }
               error={smtp.timeoutPerEmailError}
+              readOnly={readonly}
             />
           ) : (
             <InputSkeleton />
@@ -507,6 +526,7 @@ const SMTPConfigForm = observer(function SMTPConfigForm({
                 )
               }
               error={smtp.timeoutPerAttemptError}
+              readOnly={readonly}
             />
           ) : (
             <InputSkeleton />

--- a/shared/studio/tabs/auth/smtp.tsx
+++ b/shared/studio/tabs/auth/smtp.tsx
@@ -24,7 +24,11 @@ import {
 import {LoadingSkeleton} from "@edgedb/common/newui/loadingSkeleton";
 
 import styles from "./authAdmin.module.scss";
-import {InputSkeleton, StickyFormControls} from "./shared";
+import {
+  EmailProviderWarning,
+  InputSkeleton,
+  StickyFormControls,
+} from "./shared";
 import Spinner from "@edgedb/common/ui/spinner";
 import {useState} from "react";
 
@@ -39,14 +43,35 @@ export const SMTPConfigTab = observer(function SMTPConfigTab() {
       <>
         {state.emailProviders.length ? (
           <>
-            {state.noEmailProviderWarning ? (
-              <div className={styles.emailProviderWarning}>
-                <WarningIcon />
-                <span>Warning:</span> None of the configured SMTP providers
-                have been selected. Select a provider below to enable email
-                sending (eg. email verification, password reset emails, etc.)
-                in the auth extension.
-              </div>
+            {state.emailProviderWarnings.verificationNoSmtp ? (
+              <EmailProviderWarning>
+                You have auth providers requiring email verification enabled.
+                Select a provider below to enable sending verification emails.
+              </EmailProviderWarning>
+            ) : state.emailProviderWarnings.passwordNoReset ? (
+              <EmailProviderWarning>
+                You have the 'Email + Password' auth provider enabled. Select a
+                provider below to enable sending password reset emails, or{" "}
+                <span
+                  className={styles.link}
+                  onClick={() => state.setSelectedTab("webhooks")}
+                >
+                  create a webhook
+                </span>{" "}
+                for handling password resets.
+              </EmailProviderWarning>
+            ) : state.emailProviderWarnings.magicLinkNoMethods ? (
+              <EmailProviderWarning>
+                You have the 'Magic Link' auth provider enabled. Select a
+                provider below to enable sending magic links via email, or{" "}
+                <span
+                  className={styles.link}
+                  onClick={() => state.setSelectedTab("webhooks")}
+                >
+                  create a webhook
+                </span>{" "}
+                for handling magic links.
+              </EmailProviderWarning>
             ) : null}
 
             <div

--- a/shared/studio/tabs/auth/smtp.tsx
+++ b/shared/studio/tabs/auth/smtp.tsx
@@ -1,253 +1,521 @@
 import {observer} from "mobx-react-lite";
 
 import {useTabState} from "../../state";
-import {AuthAdminState, smtpSecurity, SMTPSecurity} from "./state";
+import {
+  AuthAdminState,
+  DraftSMTPConfig,
+  EmailProviderConfig,
+  smtpSecurity,
+  SMTPSecurity,
+} from "./state";
 
 import cn from "@edgedb/common/utils/classNames";
 
-import {Checkbox, FieldHeader, Select, TextInput} from "@edgedb/common/newui";
+import {
+  Button,
+  Checkbox,
+  ChevronDownIcon,
+  ConfirmButton,
+  FieldHeader,
+  Select,
+  TextInput,
+  WarningIcon,
+} from "@edgedb/common/newui";
+import {LoadingSkeleton} from "@edgedb/common/newui/loadingSkeleton";
 
 import styles from "./authAdmin.module.scss";
 import {InputSkeleton, StickyFormControls} from "./shared";
+import Spinner from "@edgedb/common/ui/spinner";
+import {useState} from "react";
 
 export const SMTPConfigTab = observer(function SMTPConfigTab() {
   const state = useTabState(AuthAdminState);
 
-  const loaded = state.smtpConfig != null;
+  let content: JSX.Element | null = null;
+  if (state.newSMTPSchema) {
+    const newDraftState = state.draftSMTPConfigs.get("");
 
-  const smtp = state.draftSMTPConfig;
+    content = state.emailProviders ? (
+      <>
+        {state.emailProviders.length ? (
+          <>
+            {state.noEmailProviderWarning ? (
+              <div className={styles.emailProviderWarning}>
+                <WarningIcon />
+                <span>Warning:</span> None of the configured SMTP providers
+                have been selected. Select a provider below to enable email
+                sending (eg. email verification, password reset emails, etc.)
+                in the auth extension.
+              </div>
+            ) : null}
 
-  const security = smtp.getConfigValue("security") as unknown as SMTPSecurity;
+            <div
+              className={cn(styles.cardList, {
+                [styles.emailProvidersUpdating]: state.updatingEmailProviders,
+              })}
+            >
+              {state.emailProviders.map((provider) => (
+                <EmailProviderCard
+                  key={provider.name}
+                  state={state}
+                  provider={provider}
+                />
+              ))}
+            </div>
+          </>
+        ) : null}
+
+        {newDraftState ? (
+          <div className={styles.addDraft}>
+            <NewDraftSMTPProviderForm
+              state={state}
+              draftState={newDraftState}
+            />
+          </div>
+        ) : (
+          <div className={styles.addDraft}>
+            <Button onClick={() => state.addDraftSMTPProvider()}>
+              Add SMTP Provider
+            </Button>
+          </div>
+        )}
+      </>
+    ) : (
+      <div className={styles.cardList}>
+        <LoadingSkeleton className={styles.emailProviderSkeleton} />
+        <LoadingSkeleton className={styles.emailProviderSkeleton} />
+      </div>
+    );
+  } else {
+    const draftState = state.draftSMTPConfigs.get("");
+
+    content = draftState ? (
+      <>
+        <SMTPConfigForm
+          loaded={draftState?.currentConfig != null}
+          smtp={draftState}
+        />
+
+        <StickyFormControls draft={draftState} />
+      </>
+    ) : null;
+  }
 
   return (
     <div className={styles.tabContentWrapper}>
       <h2>SMTP Configuration</h2>
 
-      <div className={styles.configGrid}>
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="Sender" />
-          </div>
+      {content}
+    </div>
+  );
+});
 
-          <div className={cn(styles.configInput, styles.fullWidth)}>
-            {loaded ? (
-              <TextInput
-                value={smtp.getConfigValue("sender")}
-                onChange={(e) => smtp.setConfigValue("sender", e.target.value)}
+const EmailProviderCard = observer(function EmailProviderCard({
+  state,
+  provider,
+}: {
+  state: AuthAdminState;
+  provider: EmailProviderConfig;
+}) {
+  const [updating, setUpdating] = useState(false);
+
+  const isSelectedProvider = state.currentEmailProvider === provider.name;
+  const draftState = state.draftSMTPConfigs.get(provider.name);
+
+  return (
+    <div className={cn(styles.card, styles.emailProviderCard)}>
+      <div className={styles.cardMain}>
+        {updating ? (
+          <Spinner
+            className={styles.updatingSpinner}
+            size={18.5}
+            strokeWidth={1.5}
+          />
+        ) : (
+          <svg
+            className={cn(styles.selectCurrentProvider, {
+              [styles.selected]: isSelectedProvider,
+            })}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="-6 -6 32 32"
+            fill="none"
+            onClick={() => {
+              setUpdating(true);
+              state
+                .setCurrentEmailProvider(provider.name)
+                .finally(() => setUpdating(false));
+            }}
+          >
+            <circle cx="10" cy="10" r="9.5" />
+            {isSelectedProvider ? (
+              <path
+                d="M14.6226 7.0503L8.43506 13.2378L5.62256 10.4253"
+                stroke="#fff"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
               />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            "From" address of system emails sent for e.g. password reset, etc.
-          </div>
+            ) : null}
+          </svg>
+        )}
+        <div className={styles.details}>
+          <div className={styles.name}>{provider.name}</div>
+          {provider._typename === "cfg::SMTPProviderConfig" ? (
+            <div className={styles.senderhost}>
+              {provider.sender} <span>•</span> {provider.host || "localhost"}:
+              {provider.port ||
+                (provider.security === "PlainText"
+                  ? "25"
+                  : provider.security === "TLS"
+                  ? "465"
+                  : provider.security === "STARTTLS"
+                  ? "587"
+                  : "587/25")}
+            </div>
+          ) : null}
         </div>
-
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="Host" />
-          </div>
-
-          <div className={cn(styles.configInput, styles.fullWidth)}>
-            {loaded ? (
-              <TextInput
-                value={smtp.getConfigValue("host")}
-                onChange={(e) => smtp.setConfigValue("host", e.target.value)}
-                placeholder="localhost"
-              />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            Host of SMTP server to use for sending emails. If not set,
-            "localhost" will be used.
-          </div>
-        </div>
-
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="Port" />
-          </div>
-
-          <div className={styles.configInput}>
-            {loaded ? (
-              <TextInput
-                value={smtp.getConfigValue("port")}
-                onChange={(e) => smtp.setConfigValue("port", e.target.value)}
-                placeholder={
-                  security === "STARTTLSOrPlainText"
-                    ? "587 or 25"
-                    : security === "TLS"
-                    ? "465"
-                    : security === "STARTTLS"
-                    ? "587"
-                    : "25"
-                }
-                error={smtp.portError}
-                size={10}
-              />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            Port of SMTP server to use for sending emails. If not set, common
-            defaults will be used depending on security: 465 for TLS, 587 for
-            STARTTLS, 25 otherwise.
-          </div>
-        </div>
-
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="Username" />
-          </div>
-
-          <div className={cn(styles.configInput, styles.fullWidth)}>
-            {loaded ? (
-              <TextInput
-                value={smtp.getConfigValue("username")}
-                onChange={(e) =>
-                  smtp.setConfigValue("username", e.target.value)
-                }
-              />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            Username to login as after connected to SMTP server.
-          </div>
-        </div>
-
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="New password" />
-          </div>
-
-          <div className={cn(styles.configInput, styles.fullWidth)}>
-            {loaded ? (
-              <TextInput
-                value={smtp.getConfigValue("password")}
-                onChange={(e) =>
-                  smtp.setConfigValue("password", e.target.value)
-                }
-              />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            Password for login after connected to SMTP server. Note: will
-            replace the currently configured SMTP password (if set).
-          </div>
-        </div>
-
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="Security" />
-          </div>
-
-          <div className={styles.configInput}>
-            {loaded ? (
-              <Select<SMTPSecurity>
-                className={styles.securitySelect}
-                selectedItemId={smtp.getConfigValue("security") as any}
-                onChange={(item) => smtp.setConfigValue("security", item.id)}
-                items={smtpSecurity.map((val) => ({id: val, label: val}))}
-              />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            Security mode of the connection to SMTP server. By default,
-            initiate a STARTTLS upgrade if supported by the server, or fallback
-            to PlainText.
-          </div>
-        </div>
-
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="Validate certs" />
-          </div>
-
-          <div className={styles.configInput}>
-            {loaded ? (
-              <Checkbox
-                checked={
-                  smtp._validate_certs ??
-                  state.smtpConfig?.validate_certs ??
-                  true
-                }
-                onChange={(checked) =>
-                  smtp.setConfigValue("validate_certs", checked)
-                }
-              />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            Determines if SMTP server certificates are validated.
-          </div>
-        </div>
-
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="Timeout per email" />
-          </div>
-
-          <div className={styles.configInput}>
-            {loaded ? (
-              <TextInput
-                value={smtp.getConfigValue("timeout_per_email")}
-                onChange={(e) =>
-                  smtp.setConfigValue(
-                    "timeout_per_email",
-                    e.target.value.toUpperCase()
-                  )
-                }
-                error={smtp.timeoutPerEmailError}
-              />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            Maximum time in seconds to send an email, including retry attempts.
-          </div>
-        </div>
-
-        <div className={styles.gridItem}>
-          <div className={styles.configName}>
-            <FieldHeader label="Timeout per attempt" />
-          </div>
-
-          <div className={styles.configInput}>
-            {loaded ? (
-              <TextInput
-                value={smtp.getConfigValue("timeout_per_attempt")}
-                onChange={(e) =>
-                  smtp.setConfigValue(
-                    "timeout_per_attempt",
-                    e.target.value.toUpperCase()
-                  )
-                }
-                error={smtp.timeoutPerAttemptError}
-              />
-            ) : (
-              <InputSkeleton />
-            )}
-          </div>
-          <div className={styles.configExplain}>
-            Maximum time in seconds for each SMTP request.
-          </div>
+        <div
+          className={cn(styles.expandButton, {
+            [styles.expanded]: draftState?.expanded ?? false,
+          })}
+          onClick={() =>
+            draftState
+              ? draftState.toggleExpanded()
+              : state.addDraftSMTPProvider(provider)
+          }
+        >
+          <ChevronDownIcon />
         </div>
       </div>
 
-      <StickyFormControls draft={smtp} />
+      {draftState?.expanded ? (
+        <>
+          <div className={styles.expandedEmailProviderConfig}>
+            <SMTPConfigForm loaded hasName smtp={draftState} />
+          </div>
+
+          <div className={styles.buttons}>
+            <ConfirmButton
+              style={{marginRight: "auto"}}
+              onClick={() => state.removeEmailProvider(provider.name)}
+            >
+              Remove
+            </ConfirmButton>
+
+            {draftState.formChanged ? (
+              <Button
+                disabled={draftState.updating}
+                onClick={() => draftState.clearForm()}
+              >
+                Clear changes
+              </Button>
+            ) : null}
+            <Button
+              kind="primary"
+              onClick={() => draftState.update()}
+              disabled={draftState.formError || !draftState.formChanged}
+              loading={draftState.updating}
+            >
+              {draftState.updating ? "Updating..." : "Update"}
+            </Button>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+});
+
+const NewDraftSMTPProviderForm = observer(function NewDraftSMTPProviderForm({
+  state,
+  draftState,
+}: {
+  state: AuthAdminState;
+  draftState: DraftSMTPConfig;
+}) {
+  return (
+    <div className={styles.newDraftSMTPProvider}>
+      <SMTPConfigForm loaded hasName newProvider smtp={draftState} />
+
+      <div className={styles.buttons}>
+        <Button
+          disabled={draftState.updating}
+          onClick={() => state.cancelDraftSMTPProvider()}
+        >
+          Cancel
+        </Button>
+        <Button
+          kind="primary"
+          onClick={() => draftState.update()}
+          disabled={draftState.formError || !draftState.formChanged}
+          loading={draftState.updating}
+        >
+          {draftState.updating
+            ? "Adding SMTP Provider..."
+            : "Add SMTP Provider"}
+        </Button>
+      </div>
+    </div>
+  );
+});
+
+const SMTPConfigForm = observer(function SMTPConfigForm({
+  hasName,
+  newProvider,
+  loaded,
+  smtp,
+}: {
+  hasName?: boolean;
+  newProvider?: boolean;
+  loaded: boolean;
+  smtp: DraftSMTPConfig;
+}) {
+  const security = smtp.getConfigValue("security") as unknown as SMTPSecurity;
+
+  return (
+    <div className={styles.configGrid}>
+      {hasName ? (
+        <div className={styles.gridItem}>
+          <div className={styles.configName}>
+            <FieldHeader label="Provider name" />
+          </div>
+
+          <div className={cn(styles.configInput, styles.fullWidth)}>
+            {loaded ? (
+              <TextInput
+                value={smtp.getConfigValue("name")}
+                onChange={(e) => smtp.setConfigValue("name", e.target.value)}
+                error={smtp.nameError}
+              />
+            ) : (
+              <InputSkeleton />
+            )}
+          </div>
+          <div className={styles.configExplain}>
+            The name of the email provider. Must be unique.
+          </div>
+        </div>
+      ) : null}
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label="Sender" />
+        </div>
+
+        <div className={cn(styles.configInput, styles.fullWidth)}>
+          {loaded ? (
+            <TextInput
+              value={smtp.getConfigValue("sender")}
+              onChange={(e) => smtp.setConfigValue("sender", e.target.value)}
+              error={smtp.senderError}
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          "From" address of system emails sent for e.g. password reset, etc.
+        </div>
+      </div>
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label="Host" />
+        </div>
+
+        <div className={cn(styles.configInput, styles.fullWidth)}>
+          {loaded ? (
+            <TextInput
+              value={smtp.getConfigValue("host")}
+              onChange={(e) => smtp.setConfigValue("host", e.target.value)}
+              placeholder="localhost"
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          Host of SMTP server to use for sending emails. If not set,
+          "localhost" will be used.
+        </div>
+      </div>
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label="Port" />
+        </div>
+
+        <div className={styles.configInput}>
+          {loaded ? (
+            <TextInput
+              value={smtp.getConfigValue("port")}
+              onChange={(e) => smtp.setConfigValue("port", e.target.value)}
+              placeholder={
+                security === "STARTTLSOrPlainText"
+                  ? "587 or 25"
+                  : security === "TLS"
+                  ? "465"
+                  : security === "STARTTLS"
+                  ? "587"
+                  : "25"
+              }
+              error={smtp.portError}
+              size={10}
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          Port of SMTP server to use for sending emails. If not set, common
+          defaults will be used depending on security: 465 for TLS, 587 for
+          STARTTLS, 25 otherwise.
+        </div>
+      </div>
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label="Username" />
+        </div>
+
+        <div className={cn(styles.configInput, styles.fullWidth)}>
+          {loaded ? (
+            <TextInput
+              value={smtp.getConfigValue("username")}
+              onChange={(e) => smtp.setConfigValue("username", e.target.value)}
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          Username to login as after connected to SMTP server.
+        </div>
+      </div>
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label={newProvider ? "Password" : "New password"} />
+        </div>
+
+        <div className={cn(styles.configInput, styles.fullWidth)}>
+          {loaded ? (
+            <TextInput
+              value={smtp.getConfigValue("password")}
+              onChange={(e) => smtp.setConfigValue("password", e.target.value)}
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          Password for login after connected to SMTP server.{" "}
+          {!newProvider
+            ? "Note: will replace the currently configured SMTP password."
+            : null}
+        </div>
+      </div>
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label="Security" />
+        </div>
+
+        <div className={styles.configInput}>
+          {loaded ? (
+            <Select<SMTPSecurity>
+              className={styles.securitySelect}
+              selectedItemId={smtp.getConfigValue("security") as any}
+              onChange={(item) => smtp.setConfigValue("security", item.id)}
+              items={smtpSecurity.map((val) => ({id: val, label: val}))}
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          Security mode of the connection to SMTP server. By default, initiate
+          a STARTTLS upgrade if supported by the server, or fallback to
+          PlainText.
+        </div>
+      </div>
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label="Validate certs" />
+        </div>
+
+        <div className={styles.configInput}>
+          {loaded ? (
+            <Checkbox
+              checked={
+                smtp._validate_certs ??
+                smtp.currentConfig?.validate_certs ??
+                true
+              }
+              onChange={(checked) =>
+                smtp.setConfigValue("validate_certs", checked)
+              }
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          Determines if SMTP server certificates are validated.
+        </div>
+      </div>
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label="Timeout per email" />
+        </div>
+
+        <div className={styles.configInput}>
+          {loaded ? (
+            <TextInput
+              value={smtp.getConfigValue("timeout_per_email")}
+              onChange={(e) =>
+                smtp.setConfigValue(
+                  "timeout_per_email",
+                  e.target.value.toUpperCase()
+                )
+              }
+              error={smtp.timeoutPerEmailError}
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          Maximum time in seconds to send an email, including retry attempts.
+        </div>
+      </div>
+
+      <div className={styles.gridItem}>
+        <div className={styles.configName}>
+          <FieldHeader label="Timeout per attempt" />
+        </div>
+
+        <div className={styles.configInput}>
+          {loaded ? (
+            <TextInput
+              value={smtp.getConfigValue("timeout_per_attempt")}
+              onChange={(e) =>
+                smtp.setConfigValue(
+                  "timeout_per_attempt",
+                  e.target.value.toUpperCase()
+                )
+              }
+              error={smtp.timeoutPerAttemptError}
+            />
+          ) : (
+            <InputSkeleton />
+          )}
+        </div>
+        <div className={styles.configExplain}>
+          Maximum time in seconds for each SMTP request.
+        </div>
+      </div>
     </div>
   );
 });

--- a/shared/studio/tabs/auth/smtp.tsx
+++ b/shared/studio/tabs/auth/smtp.tsx
@@ -103,12 +103,37 @@ export const SMTPConfigTab = observer(function SMTPConfigTab() {
 
   return (
     <div className={styles.tabContentWrapper}>
-      <h2>SMTP Configuration</h2>
+      <div className={styles.titleWrapper}>
+        <h2>SMTP Configuration</h2>
+
+        <ResetCurrentProviderButton state={state} />
+      </div>
 
       {content}
     </div>
   );
 });
+
+function ResetCurrentProviderButton({state}: {state: AuthAdminState}) {
+  const [loading, setLoading] = useState(false);
+
+  return state.currentEmailProvider === null ? null : (
+    <Button
+      kind="outline"
+      loading={loading}
+      onClick={async () => {
+        setLoading(true);
+        try {
+          await state.resetCurrentEmailProvider();
+        } finally {
+          setLoading(false);
+        }
+      }}
+    >
+      Disable all SMTP providers
+    </Button>
+  );
+}
 
 const EmailProviderCard = observer(function EmailProviderCard({
   state,
@@ -141,9 +166,10 @@ const EmailProviderCard = observer(function EmailProviderCard({
             fill="none"
             onClick={() => {
               setUpdating(true);
-              state
-                .setCurrentEmailProvider(provider.name)
-                .finally(() => setUpdating(false));
+              (isSelectedProvider
+                ? state.resetCurrentEmailProvider()
+                : state.setCurrentEmailProvider(provider.name)
+              ).finally(() => setUpdating(false));
             }}
           >
             <circle cx="10" cy="10" r="9.5" />

--- a/shared/studio/tabs/auth/smtp.tsx
+++ b/shared/studio/tabs/auth/smtp.tsx
@@ -217,26 +217,30 @@ const EmailProviderCard = observer(function EmailProviderCard({
       {draftState?.expanded ? (
         <>
           <div className={styles.expandedEmailProviderConfig}>
-            <SMTPConfigForm
-              smtp={draftState}
-              loaded
-              hasName
-              newProvider
-              readonly
-            />
+            <SMTPConfigForm smtp={draftState} loaded hasName />
           </div>
+
+          {draftState.formChanged &&
+          draftState.getConfigValue("password").trim() === "" ? (
+            <div className={styles.passwordWarning}>
+              <WarningIcon />
+              <div>
+                <span>Warning:</span> You have not entered a password. If there
+                is an existing password, it will be deleted when you update
+                this SMTP provider unless you re-enter the password above.
+              </div>
+            </div>
+          ) : null}
 
           <div className={styles.buttons}>
             <ConfirmButton
+              style={{marginRight: "auto"}}
               onClick={() => state.removeEmailProvider(provider.name)}
             >
               Remove
             </ConfirmButton>
 
-            {/* Hide this for now since the config system doesn't have a good way
-            to update objects, other than delete+insert which loses the secret
-            password field (unless the user re-enters it) */}
-            {/* {draftState.formChanged ? (
+            {draftState.formChanged ? (
               <Button
                 disabled={draftState.updating}
                 onClick={() => draftState.clearForm()}
@@ -251,7 +255,7 @@ const EmailProviderCard = observer(function EmailProviderCard({
               loading={draftState.updating}
             >
               {draftState.updating ? "Updating..." : "Update"}
-            </Button> */}
+            </Button>
           </div>
         </>
       ) : null}

--- a/shared/studio/tabs/auth/smtp.tsx
+++ b/shared/studio/tabs/auth/smtp.tsx
@@ -46,7 +46,15 @@ export const SMTPConfigTab = observer(function SMTPConfigTab() {
             {state.emailProviderWarnings.verificationNoSmtp ? (
               <EmailProviderWarning>
                 You have auth providers requiring email verification enabled.
-                Select a provider below to enable sending verification emails.
+                Select a provider below to enable sending verification emails,
+                or{" "}
+                <span
+                  className={styles.link}
+                  onClick={() => state.setSelectedTab("webhooks")}
+                >
+                  create a webhook
+                </span>{" "}
+                for handling email verification.
               </EmailProviderWarning>
             ) : state.emailProviderWarnings.passwordNoReset ? (
               <EmailProviderWarning>

--- a/shared/studio/tabs/auth/state/index.tsx
+++ b/shared/studio/tabs/auth/state/index.tsx
@@ -392,6 +392,22 @@ export class AuthAdminState extends Model({
     }
   }
 
+  @action
+  async resetCurrentEmailProvider() {
+    this.updatingEmailProviders = true;
+
+    const conn = connCtx.get(this)!;
+
+    try {
+      await conn.execute(
+        `configure current branch reset current_email_provider_name`
+      );
+      await this.refreshConfig();
+    } finally {
+      runInAction(() => (this.updatingEmailProviders = false));
+    }
+  }
+
   @computed
   get noEmailProviderWarning() {
     return (

--- a/shared/studio/tabs/auth/webhooks.tsx
+++ b/shared/studio/tabs/auth/webhooks.tsx
@@ -31,7 +31,19 @@ export const WebhooksTab = observer(function WebhooksTab() {
     <div className={styles.tabContentWrapper}>
       <h2>Webhooks</h2>
 
-      {state.emailProviderWarnings.passwordNoReset ? (
+      {state.emailProviderWarnings.verificationNoSmtp ? (
+        <EmailProviderWarning>
+          You have auth providers requiring email verification enabled. Create
+          a webhook below to handle the 'EmailVerificationRequested' event, or{" "}
+          <span
+            className={styles.link}
+            onClick={() => state.setSelectedTab("smtp")}
+          >
+            enable an SMTP provider
+          </span>{" "}
+          to send verification emails.
+        </EmailProviderWarning>
+      ) : state.emailProviderWarnings.passwordNoReset ? (
         <EmailProviderWarning>
           You have the 'Email + Password' auth provider enabled. Create a
           webhook below to handle the 'PasswordResetRequested' event, or{" "}
@@ -127,17 +139,18 @@ function WebhookConfigCard({config}: {config: WebhookConfigData}) {
           </div>
           <div className={styles.webhookEvents}>
             <FieldHeader label="Events" />
-            <div
-              className={styles.grid}
-              style={{"--itemCount": webhookEvents.length} as any}
-            >
-              {webhookEvents.map((event) => (
-                <Checkbox
-                  readOnly
-                  key={event}
-                  label={event}
-                  checked={config.events.includes(event)}
-                />
+            <div className={styles.grid}>
+              {webhookEvents.map((col, i) => (
+                <div key={i}>
+                  {col.map(({name, label}) => (
+                    <Checkbox
+                      readOnly
+                      key={name}
+                      label={label}
+                      checked={config.events.includes(name)}
+                    />
+                  ))}
+                </div>
               ))}
             </div>
           </div>
@@ -187,23 +200,24 @@ const WebhookDraftForm = observer(function WebhookDraftForm({
           label="Events"
           headerNote="At least one event must be selected"
         />
-        <div
-          className={styles.grid}
-          style={{"--itemCount": webhookEvents.length} as any}
-        >
-          {webhookEvents.map((event) => (
-            <Checkbox
-              key={event}
-              label={event}
-              checked={draft.events.has(event)}
-              onChange={(checked) => {
-                if (checked) {
-                  draft.events.add(event);
-                } else {
-                  draft.events.delete(event);
-                }
-              }}
-            />
+        <div className={styles.grid}>
+          {webhookEvents.map((col, i) => (
+            <div key={i}>
+              {col.map(({name, label}) => (
+                <Checkbox
+                  key={name}
+                  label={label}
+                  checked={draft.events.has(name)}
+                  onChange={(checked) => {
+                    if (checked) {
+                      draft.events.add(name);
+                    } else {
+                      draft.events.delete(name);
+                    }
+                  }}
+                />
+              ))}
+            </div>
           ))}
         </div>
       </div>

--- a/shared/studio/tabs/auth/webhooks.tsx
+++ b/shared/studio/tabs/auth/webhooks.tsx
@@ -22,6 +22,7 @@ import {
 import styles from "./authAdmin.module.scss";
 import {useState} from "react";
 import {LoadingSkeleton} from "@edgedb/common/newui/loadingSkeleton";
+import {EmailProviderWarning} from "./shared";
 
 export const WebhooksTab = observer(function WebhooksTab() {
   const state = useTabState(AuthAdminState);
@@ -29,6 +30,33 @@ export const WebhooksTab = observer(function WebhooksTab() {
   return (
     <div className={styles.tabContentWrapper}>
       <h2>Webhooks</h2>
+
+      {state.emailProviderWarnings.passwordNoReset ? (
+        <EmailProviderWarning>
+          You have the 'Email + Password' auth provider enabled. Create a
+          webhook below to handle the 'PasswordResetRequested' event, or{" "}
+          <span
+            className={styles.link}
+            onClick={() => state.setSelectedTab("smtp")}
+          >
+            enable an SMTP provider
+          </span>{" "}
+          to send password resets.
+        </EmailProviderWarning>
+      ) : state.emailProviderWarnings.magicLinkNoMethods ? (
+        <EmailProviderWarning>
+          You have the 'Magic Link' auth provider enabled. Create a webhook
+          below to handle the 'MagicLinkRequested' event, or{" "}
+          <span
+            className={styles.link}
+            onClick={() => state.setSelectedTab("smtp")}
+          >
+            enable an SMTP provider
+          </span>{" "}
+          to send magic links.
+        </EmailProviderWarning>
+      ) : null}
+
       {state.webhooks ? (
         <>
           {state.webhooks.length ? (


### PR DESCRIPTION
Adds support for the new SMTP config introduced in https://github.com/edgedb/edgedb/pull/7942.

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/58e6fe96-a827-4256-8da9-766f048083b0">



@scotttrinh I'm not sure how the cloud magic smtp provider will be introspected, is it going to be a another type extending `cfg::EmailProvider` that won't be user configurable, or is it another `SMTPProviderConfig` which we have to make readonly in the UI?

~Also there's a new potential tripping hazard when updating an existing smtp provider, as I think we now have to update the whole config object, so that will reset the password every time unless you re-enter the password whenever you make a change.~
~Disabled editing of smtp configs for now.~
Re-enabled smtp config editing, but with a warning message if you don't re-enter the password.