### PR TITLE
Update design of query editor tab

### DIFF
--- a/shared/common/components/dataGrid/index.tsx
+++ b/shared/common/components/dataGrid/index.tsx
@@ -174,19 +174,21 @@ export const GridContent = observer(function GridContent({
   state,
   pinnedCells,
   cells,
+  bottomPadding,
 }: {
   className?: string;
   style?: React.CSSProperties;
   state: DataGridState;
   pinnedCells?: React.ReactNode;
   cells: React.ReactNode;
+  bottomPadding?: number;
 }) {
   return (
     <div
       className={cn(styles.gridContent, className)}
       style={{
         ...style,
-        height: state.gridContentHeight,
+        height: state.gridContentHeight + (bottomPadding ?? 0),
         width: state.gridContentWidth,
       }}
     >

--- a/shared/common/components/infoCards/index.tsx
+++ b/shared/common/components/infoCards/index.tsx
@@ -27,7 +27,7 @@ export function InfoCards({
   className?: string;
   listClassName?: string;
   extraCards?: (InfoCardDef | null)[];
-  currentVersion?: {major: number; minor: number; stage: string} | null;
+  currentVersion?: {major: number; minor: number} | null;
 }) {
   const data = useLatestInfo();
 

--- a/shared/common/components/resultGrid/index.tsx
+++ b/shared/common/components/resultGrid/index.tsx
@@ -24,10 +24,12 @@ export {createResultGridState, ResultGridState} from "./state";
 
 export interface ResultGridProps extends Omit<DataGridProps, "state"> {
   state: ResultGridState;
+  bottomPadding?: number;
 }
 
 export const ResultGrid = observer(function ResultGrid({
   state,
+  bottomPadding,
   ...props
 }: ResultGridProps) {
   useEffect(() => {
@@ -51,7 +53,7 @@ export const ResultGrid = observer(function ResultGrid({
   return (
     <DataGrid state={state.grid} {...props}>
       <ResultGridHeaders state={state} />
-      <ResultGridContent state={state} />
+      <ResultGridContent state={state} bottomPadding={bottomPadding} />
     </DataGrid>
   );
 });
@@ -131,6 +133,7 @@ export const ResultGridHeaders = observer(function ResultGridHeaders({
 
 export const ResultGridContent = observer(function ResultGridContent({
   state,
+  bottomPadding,
 }: ResultGridProps) {
   const ranges = state.grid.visibleRanges;
   const rowTops = state.rowTops;
@@ -191,6 +194,7 @@ export const ResultGridContent = observer(function ResultGridContent({
       style={{"--gridHeaderHeight": state.grid.headerHeight + "px"} as any}
       state={state.grid}
       cells={cells}
+      bottomPadding={bottomPadding}
     />
   );
 });

--- a/shared/common/mixins.scss
+++ b/shared/common/mixins.scss
@@ -39,6 +39,7 @@
 
 $breakpoints: (
   mobile: 768px,
+  tablet: 1024px,
 );
 
 @mixin breakpoint($breakpoint) {

--- a/shared/common/newui/copyButton/index.tsx
+++ b/shared/common/newui/copyButton/index.tsx
@@ -8,7 +8,7 @@ import {Button} from "../button";
 
 export interface CopyButtonProps {
   className?: string;
-  content: string;
+  content: string | (() => string);
   mini?: boolean;
 }
 
@@ -25,7 +25,7 @@ export function CopyButton({className, content, mini}: CopyButtonProps) {
   }, [copied]);
 
   const onCopy = () => {
-    navigator.clipboard?.writeText(content);
+    navigator.clipboard?.writeText(typeof content === 'string' ? content : content());
     setCopied(true);
   };
 

--- a/shared/common/newui/iconToggle/iconToggle.module.scss
+++ b/shared/common/newui/iconToggle/iconToggle.module.scss
@@ -17,6 +17,10 @@
     background: var(--Grey16);
     border-color: var(--Grey14);
   }
+
+  @include isMobile {
+    border-radius: 10px;
+  }
 }
 
 .option {
@@ -76,5 +80,14 @@
   &:hover .label {
     opacity: 1;
     transition-delay: 0.4s;
+  }
+
+  @include isMobile {
+    width: 38px;
+    height: 38px;
+
+    &.selected:before {
+      border-radius: 8px;
+    }
   }
 }

--- a/shared/common/newui/iconToggle/iconToggle.module.scss
+++ b/shared/common/newui/iconToggle/iconToggle.module.scss
@@ -1,0 +1,80 @@
+@import "@edgedb/common/mixins.scss";
+
+.iconToggle {
+  display: flex;
+  background: var(--Grey95);
+  border: 1px solid var(--Grey90);
+  border-radius: 8px;
+  font-family: "Roboto Flex Variable", sans-serif;
+  line-height: 16px;
+
+  &.disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
+
+  @include darkTheme {
+    background: var(--Grey16);
+    border-color: var(--Grey14);
+  }
+}
+
+.option {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  svg {
+    color: var(--Grey55);
+    z-index: 1;
+
+    @include darkTheme {
+      color: var(--Grey65);
+    }
+  }
+
+  &.selected:before {
+    content: "";
+    position: absolute;
+    inset: 2px;
+    border-radius: 6px;
+    background: #fff;
+    box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.16);
+
+    @include darkTheme {
+      background: var(--Grey30);
+      box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.4);
+    }
+  }
+
+  &.disabled {
+    opacity: 0.3;
+    pointer-events: none;
+  }
+
+  .label {
+    position: absolute;
+    top: calc(100% + 2px);
+    white-space: nowrap;
+    background: var(--panel_background);
+    padding: 6px 10px;
+    border-radius: 6px;
+    color: var(--secondary_text_color);
+    font-weight: 500;
+    font-size: 13px;
+    border: 1px solid var(--panel_border);
+    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.08);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s linear;
+  }
+
+  &:hover .label {
+    opacity: 1;
+    transition-delay: 0.4s;
+  }
+}

--- a/shared/common/newui/iconToggle/index.tsx
+++ b/shared/common/newui/iconToggle/index.tsx
@@ -1,0 +1,40 @@
+import cn from "@edgedb/common/utils/classNames";
+
+import styles from "./iconToggle.module.scss";
+
+export interface IconToggleProps<OptionKey extends string | number> {
+  options: {
+    key: OptionKey;
+    label: string;
+    icon: JSX.Element;
+    disabled?: boolean;
+  }[];
+  selectedOption: OptionKey;
+  onSelectOption: (key: OptionKey) => void;
+  disabled?: boolean;
+}
+
+export function IconToggle<OptionKey extends string | number = any>({
+  options,
+  selectedOption,
+  onSelectOption,
+  disabled,
+}: IconToggleProps<OptionKey>) {
+  return (
+    <div className={cn(styles.iconToggle, {[styles.disabled]: !!disabled})}>
+      {options.map((option) => (
+        <div
+          key={option.key}
+          className={cn(styles.option, {
+            [styles.selected]: option.key === selectedOption,
+            [styles.disabled]: !!option.disabled,
+          })}
+          onClick={() => onSelectOption(option.key)}
+        >
+          {option.icon}
+          <div className={styles.label}>{option.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/shared/common/newui/iconToggle/index.tsx
+++ b/shared/common/newui/iconToggle/index.tsx
@@ -3,6 +3,7 @@ import cn from "@edgedb/common/utils/classNames";
 import styles from "./iconToggle.module.scss";
 
 export interface IconToggleProps<OptionKey extends string | number> {
+  className?: string;
   options: {
     key: OptionKey;
     label: string;
@@ -15,13 +16,14 @@ export interface IconToggleProps<OptionKey extends string | number> {
 }
 
 export function IconToggle<OptionKey extends string | number = any>({
+  className,
   options,
   selectedOption,
   onSelectOption,
   disabled,
 }: IconToggleProps<OptionKey>) {
   return (
-    <div className={cn(styles.iconToggle, {[styles.disabled]: !!disabled})}>
+    <div className={cn(styles.iconToggle, className, {[styles.disabled]: !!disabled})}>
       {options.map((option) => (
         <div
           key={option.key}

--- a/shared/common/newui/icons/index.tsx
+++ b/shared/common/newui/icons/index.tsx
@@ -705,3 +705,155 @@ export function FilterIcon({className}: {className?: string}) {
     </svg>
   );
 }
+
+export function RunIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 5.57143L17 12L7 18.4286V5.57143Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function SplitViewIcon(props: {
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <rect
+        x="5.75"
+        y="5.75"
+        width="12.5"
+        height="4.5"
+        rx="1.25"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <rect
+        x="5.75"
+        y="13.75"
+        width="12.5"
+        height="4.5"
+        rx="1.25"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+export function TreeViewIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="9.75"
+        y="8.75"
+        width="10.5"
+        height="3.5"
+        rx="1.25"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <rect
+        x="9.75"
+        y="15.75"
+        width="10.5"
+        height="3.5"
+        rx="1.25"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M9.5 17.5H8.5C6.84315 17.5 5.5 16.1569 5.5 14.5V7.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M9.5 10.5H8.5C6.84315 10.5 5.5 9.15685 5.5 7.5V7.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle
+        cx="5.5"
+        cy="5.5"
+        r="1.75"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+export function TableViewIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="3.75"
+        y="3.75"
+        width="16.5"
+        height="16"
+        rx="1.25"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M4 9H20M9.5 4V19.5M4 14.5H20"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+export function HistoryIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 14.4853 4.00736 16.7353 5.63604 18.364M11 7.6V13L14.6 14.8M5.63604 18.364L6.5 14.5M5.63604 18.364L1.5 17.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/shared/common/newui/index.ts
+++ b/shared/common/newui/index.ts
@@ -7,3 +7,4 @@ export * from "./icons";
 export * from "./logos";
 export * from "./infoTooltip";
 export * from "./modal";
+export * from "./iconToggle";

--- a/shared/common/ui/splitView/index.tsx
+++ b/shared/common/ui/splitView/index.tsx
@@ -98,8 +98,7 @@ export default observer(function SplitView({
     >
       {views.map((view, viewIndex) => {
         const lastView = viewIndex === views.length - 1;
-        const margins =
-          3 + (viewIndex === 0 ? -1.5 : 0) + (lastView ? -1.5 : 0);
+        const margins = 2 + (viewIndex === 0 ? -1 : 0) + (lastView ? -1 : 0);
         const size = {
           [childSizeKey]: `calc(${state.sizes[viewIndex]}%${
             margins ? ` - ${margins}px` : ""
@@ -117,7 +116,6 @@ export default observer(function SplitView({
             {!lastView ? (
               <Resizer
                 direction={state.direction}
-                onFlip={() => state.flipSplitDirection()}
                 onResizeStart={(e) =>
                   resizeHandler(e, {
                     viewIndex,
@@ -134,7 +132,6 @@ export default observer(function SplitView({
 
 interface ResizerProps {
   direction: SplitViewDirection;
-  onFlip: () => void;
   onResizeStart: (event: React.MouseEvent) => void;
 }
 
@@ -142,7 +139,6 @@ function Resizer({onResizeStart}: ResizerProps) {
   return (
     <div className={styles.resizer}>
       <div className={styles.grabHandle} onMouseDown={onResizeStart}></div>
-      {/* <div className={styles.resizerFlip} onClick={onFlip}></div> */}
       <div className={styles.resizerIndicator} />
     </div>
   );

--- a/shared/common/ui/splitView/index.tsx
+++ b/shared/common/ui/splitView/index.tsx
@@ -29,13 +29,14 @@ export default observer(function SplitView({
   ...otherProps
 }: React.HTMLAttributes<HTMLDivElement> & SplitViewProps) {
   const [_, setGlobalDragCursor] = useGlobalDragCursor();
-
-  const childSizeKey =
-    state.direction === SplitViewDirection.vertical ? "height" : "width";
+  const isMobile = useIsMobile();
 
   const ref = useRef<HTMLDivElement>(null);
 
-  const isMobile = useIsMobile();
+  const childSizeKey =
+    !isMobile && state.direction === SplitViewDirection.vertical
+      ? "height"
+      : "width";
 
   const resizeHandler = useDragHandler<ResizeDragHandlerParams>(() => {
     let initialPos: Position;
@@ -93,7 +94,7 @@ export default observer(function SplitView({
       ref={ref}
       className={cn(className, styles.splitViewContainer, {
         [styles.splitVertical]:
-          state.direction === SplitViewDirection.vertical,
+          !isMobile && state.direction === SplitViewDirection.vertical,
       })}
     >
       {views.map((view, viewIndex) => {

--- a/shared/common/ui/splitView/model.ts
+++ b/shared/common/ui/splitView/model.ts
@@ -7,7 +7,9 @@ export enum SplitViewDirection {
 
 @model("SplitViewState")
 export class SplitViewState extends Model({
-  direction: prop<SplitViewDirection>(SplitViewDirection.horizontal),
+  direction: prop<SplitViewDirection>(
+    SplitViewDirection.horizontal
+  ).withSetter(),
   sizes: prop<[number, number]>(() => [50, 50]).withSetter(),
   activeViewIndex: prop<0 | 1>(0).withSetter(),
 }) {

--- a/shared/common/ui/splitView/splitView.module.scss
+++ b/shared/common/ui/splitView/splitView.module.scss
@@ -29,10 +29,7 @@
     z-index: 0;
 
     &:last-child {
-      position: absolute;
-      top: 0;
-      left: 0;
-      height: 100%;
+      height: 100% !important;
     }
   }
 }

--- a/shared/common/ui/splitView/splitView.module.scss
+++ b/shared/common/ui/splitView/splitView.module.scss
@@ -24,15 +24,6 @@
   flex-grow: 0;
   background: var(--app_panel_background);
 
-  &:first-child {
-    border-top-left-radius: 8px;
-    border-bottom-left-radius: 8px;
-  }
-  &:last-child {
-    border-top-right-radius: 8px;
-    border-bottom-right-radius: 8px;
-  }
-
   @include breakpoint(mobile) {
     width: 100% !important;
     z-index: 0;
@@ -44,29 +35,17 @@
       height: 100%;
     }
   }
-
-  .splitVertical & {
-    &:first-child {
-      border-top-right-radius: 8px;
-      border-bottom-left-radius: 4px;
-    }
-
-    &:last-child {
-      border-bottom-left-radius: 8px;
-      border-top-right-radius: 4px;
-    }
-  }
 }
 
 .resizer {
-  min-width: 3px;
-  min-height: 3px;
+  min-width: 2px;
+  min-height: 2px;
   position: relative;
   z-index: 100;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #e2e2e2;
+  background: #e4e4e4;
 
   @include breakpoint(mobile) {
     display: none;
@@ -78,18 +57,18 @@
 
   .grabHandle {
     position: absolute;
-    top: -3px;
-    bottom: -3px;
-    left: -3px;
-    right: -3px;
+    top: -4px;
+    bottom: -4px;
+    left: -4px;
+    right: -4px;
     cursor: ew-resize;
   }
 
   .resizerIndicator {
-    width: 9px;
-    height: 38px;
+    width: 7px;
+    height: 36px;
     flex-shrink: 0;
-    background: #e2e2e2;
+    background: #e4e4e4;
     border-radius: 5px;
     pointer-events: none;
 
@@ -99,16 +78,16 @@
       width: 3px;
       height: 32px;
       background: var(--panel_background);
-      margin: 3px;
+      margin: 2px;
       border-radius: 2px;
     }
 
     .splitVertical & {
-      height: 10px;
-      width: 40px;
+      height: 7px;
+      width: 36px;
 
       &:after {
-        height: 2px;
+        height: 3px;
         width: 32px;
       }
     }
@@ -118,46 +97,9 @@
     }
   }
 
-  .resizerFlip {
-    min-width: 8px;
-    height: 19px;
-    border-radius: 2px;
-    background-color: var(--resizer-flip-background, var(--bgColour));
-    color: var(--resizer-flip-icon);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: height 0.1s, min-width 0.1s;
-    cursor: pointer;
-    z-index: 1;
-
-    svg {
-      opacity: 0;
-      transition: opacity 0.1s;
-    }
-  }
-
   .splitVertical > & {
     .grabHandle {
       cursor: ns-resize;
-    }
-
-    .resizerFlip {
-      height: 8px;
-      width: 19px;
-    }
-  }
-
-  &:hover {
-    .resizerFlip {
-      height: 19px;
-      min-width: 19px;
-      transition-delay: 0.2s;
-
-      svg {
-        opacity: 1;
-        transition-delay: 0.2s;
-      }
     }
   }
 }

--- a/shared/common/ui/switch/switch.module.scss
+++ b/shared/common/ui/switch/switch.module.scss
@@ -102,41 +102,52 @@
 
 .labelsSwitch {
   display: flex;
-  padding: 4px;
-  background: #999;
-  border-radius: 22px;
-  align-items: center;
-  height: 32px;
+  padding: 2px;
+  background: var(--Grey93);
+  border-radius: 10px;
+  border: 1px solid var(--Grey90);
+  height: 34px;
 
   .radio {
+    display: flex;
+
     input {
       display: none;
     }
 
     .label {
-      color: #fff;
-      font-family: Roboto;
-      font-size: 12px;
+      display: flex;
+      align-items: center;
+      color: var(--Grey50);
+      font-family: "Roboto Flex Variable", sans-serif;
+      font-size: 14px;
       font-weight: 500;
       line-height: 16px;
-      text-transform: uppercase;
-      border-radius: 16px;
-      padding: 8px 10px;
+      border-radius: 8px;
+      padding: 0 10px;
+      cursor: pointer;
     }
 
     .checked {
       background: #fff;
-      color: #666;
+      box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.16);
+      color: var(--Grey45);
     }
+  }
 
-    @include darkTheme {
+  @include darkTheme {
+    background: var(--Grey10);
+    border-color: var(--Grey18);
+
+    .radio {
       .label {
-        color: #242424;
+        color: var(--Grey65);
       }
 
       .checked {
-        background: #141414;
-        color: #999;
+        background: var(--Grey30);
+        box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.4);
+        color: var(--Grey70);
       }
     }
   }

--- a/shared/common/utils/relativeTime.tsx
+++ b/shared/common/utils/relativeTime.tsx
@@ -67,7 +67,7 @@ export const RelativeTime = observer(function RelativeTime({
     return (
       <>
         {sec}
-        {fullNames ? (sec != 0 ? " seconds" : " second") : "s"} ago
+        {fullNames ? (sec != 1 ? " seconds" : " second") : "s"} ago
       </>
     );
   }
@@ -76,7 +76,7 @@ export const RelativeTime = observer(function RelativeTime({
     return (
       <>
         {min}
-        {fullNames ? (min != 0 ? " minutes" : " minute") : "m"} ago
+        {fullNames ? (min != 1 ? " minutes" : " minute") : "m"} ago
       </>
     );
   }

--- a/shared/common/utils/relativeTime.tsx
+++ b/shared/common/utils/relativeTime.tsx
@@ -63,18 +63,20 @@ export const RelativeTime = observer(function RelativeTime({
     return <>Just now</>;
   }
   if (diff < 60) {
+    const sec = Math.floor(diff);
     return (
       <>
-        {Math.floor(diff)}
-        {fullNames ? " seconds" : "s"} ago
+        {sec}
+        {fullNames ? (sec != 0 ? " seconds" : " second") : "s"} ago
       </>
     );
   }
   if (diff < 3600) {
+    const min = Math.floor(diff / 60);
     return (
       <>
-        {Math.floor(diff / 60)}
-        {fullNames ? " minutes" : "m"} ago
+        {min}
+        {fullNames ? (min != 0 ? " minutes" : " minute") : "m"} ago
       </>
     );
   }

--- a/shared/studio/components/visualQuerybuilder/index.tsx
+++ b/shared/studio/components/visualQuerybuilder/index.tsx
@@ -2,7 +2,7 @@ import {observer} from "mobx-react-lite";
 import cn from "@edgedb/common/utils/classNames";
 import {useDatabaseState, useTabState} from "../../state";
 import {SchemaData} from "../../state/database";
-import {EditorKind, QueryEditor} from "../../tabs/queryEditor/state";
+import {QueryEditor} from "../../tabs/queryEditor/state";
 import {
   QueryBuilderShape,
   FilterExpr,
@@ -15,11 +15,10 @@ import {SchemaObjectType, SchemaProperty} from "@edgedb/common/schemaData";
 
 import styles from "./queryBuilder.module.scss";
 import {Select} from "@edgedb/common/ui/select";
-import {CopyIcon, DeleteIcon} from "../../icons";
+import {DeleteIcon} from "../../icons";
 import {CustomScrollbars} from "@edgedb/common/ui/customScrollbar";
-import Button from "@edgedb/common/ui/button";
 import {ObjectTypeSelect, sortObjectTypes} from "../objectTypeSelect";
-import {useEffect, useLayoutEffect, useState} from "react";
+import {useLayoutEffect} from "react";
 import {CopyButton} from "@edgedb/common/newui/copyButton";
 
 export const VisualQuerybuilder = observer(function VisualQuerybuilder({

--- a/shared/studio/components/visualQuerybuilder/index.tsx
+++ b/shared/studio/components/visualQuerybuilder/index.tsx
@@ -19,7 +19,8 @@ import {CopyIcon, DeleteIcon} from "../../icons";
 import {CustomScrollbars} from "@edgedb/common/ui/customScrollbar";
 import Button from "@edgedb/common/ui/button";
 import {ObjectTypeSelect, sortObjectTypes} from "../objectTypeSelect";
-import {useEffect, useState} from "react";
+import {useEffect, useLayoutEffect, useState} from "react";
+import {CopyButton} from "@edgedb/common/newui/copyButton";
 
 export const VisualQuerybuilder = observer(function VisualQuerybuilder({
   state,
@@ -28,26 +29,26 @@ export const VisualQuerybuilder = observer(function VisualQuerybuilder({
 }) {
   const schemaData = useDatabaseState().schemaData;
 
-  if (!schemaData) {
-    return <div>loading schema...</div>;
-  }
-
   const schemaObjectTypes = sortObjectTypes(
-    [...schemaData.objects.values()].filter(
+    [...(schemaData?.objects.values() ?? [])].filter(
       (type) =>
         !type.builtin && !type.unionOf && !type.insectionOf && !type.from_alias
     )
   );
 
-  if (state.root.typename === null) {
-    state.setRoot(
-      new QueryBuilderShape({
-        typename: schemaObjectTypes[0]?.name,
-      })
-    );
-  }
+  useLayoutEffect(() => {
+    if (state.root.typename === null) {
+      state.setRoot(
+        new QueryBuilderShape({
+          typename: schemaObjectTypes[0]?.name,
+        })
+      );
+    }
+  }, [schemaObjectTypes]);
 
-  return (
+  return !schemaData ? (
+    <div>loading schema...</div>
+  ) : (
     <QuerybuilderRoot
       schemaData={schemaData}
       state={state}
@@ -67,23 +68,6 @@ const QuerybuilderRoot = observer(function QuerybuilderRoot({
 }) {
   const editorState = useTabState(QueryEditor);
 
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (copied) {
-      const timeout = setTimeout(() => setCopied(false), 1000);
-      return () => {
-        clearTimeout(timeout);
-      };
-    }
-  }, [copied]);
-
-  const copyQuery = () => {
-    const query = editorState.currentQueryData[EditorKind.VisualBuilder].query;
-    navigator.clipboard?.writeText(query);
-    setCopied(true);
-  };
-
   return (
     <>
       <CustomScrollbars
@@ -96,7 +80,7 @@ const QuerybuilderRoot = observer(function QuerybuilderRoot({
             [styles.flexCenter]: !schemaObjectTypes.length,
           })}
         >
-          {schemaObjectTypes.length ? (
+          {schemaObjectTypes.length && state.root.typename ? (
             <>
               <div className={styles.scrollInner}>
                 <div className={styles.shapeBlock}>
@@ -126,9 +110,11 @@ const QuerybuilderRoot = observer(function QuerybuilderRoot({
                   />
                 </div>
               </div>
-              <div className={styles.copyButton} onClick={copyQuery}>
-                <CopyIcon /> {copied ? "Copied" : "Copy"}
-              </div>
+              <CopyButton
+                className={styles.copyButton}
+                content={() => state.query}
+                mini
+              />
             </>
           ) : (
             <p className={styles.emptySchemaText}>
@@ -145,18 +131,6 @@ const QuerybuilderRoot = observer(function QuerybuilderRoot({
           )}
         </div>
       </CustomScrollbars>
-
-      {editorState.showHistory ? null : (
-        <div className={styles.controls}>
-          <Button
-            className={styles.runButton}
-            label="Run"
-            disabled={!editorState.canRunQuery}
-            loading={editorState.queryRunning}
-            onClick={() => editorState.runQuery()}
-          />
-        </div>
-      )}
     </>
   );
 });

--- a/shared/studio/components/visualQuerybuilder/queryBuilder.module.scss
+++ b/shared/studio/components/visualQuerybuilder/queryBuilder.module.scss
@@ -38,36 +38,17 @@
     position: absolute;
     right: 8px;
     top: 8px;
-    display: flex;
-    align-items: center;
-    font-family: "Roboto";
-    font-style: normal;
-    font-weight: 500;
-    font-size: 11px;
-    line-height: 24px;
-    text-transform: uppercase;
-    color: #777;
-    background: #ededed;
-    cursor: pointer;
-    padding: 2px 8px;
-    border-radius: 6px;
-    cursor: pointer;
-
-    svg {
-      fill: currentColor;
-      margin-right: 6px;
-    }
-
-    &:hover {
-      color: #1f8aed;
-      background: #e8e8e8;
-    }
+    padding: 6px;
+    background: var(--Grey99);
+    border: 1px solid var(--Grey90);
 
     @include darkTheme {
-      background: #2b2b2b;
+      background: var(--Grey18);
+      border: 1px solid var(--Grey25);
+      color: var(--Grey40);
 
       &:hover {
-        background: #353535;
+        color: var(--Grey50);
       }
     }
   }
@@ -93,22 +74,6 @@
 
   .select {
     color: var(--app-code);
-  }
-}
-
-.controls {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  margin: 8px;
-  pointer-events: none;
-
-  .runButton {
-    --buttonBg: var(--app-accent-green);
-    --buttonTextColour: #0a4634;
-    align-self: flex-start;
-    flex-shrink: 0;
-    pointer-events: auto;
   }
 }
 

--- a/shared/studio/state/connection.ts
+++ b/shared/studio/state/connection.ts
@@ -6,6 +6,7 @@ import {
   prop,
   _async,
   _await,
+  Frozen,
 } from "mobx-keystone";
 
 import {AuthenticationError} from "edgedb";
@@ -118,11 +119,15 @@ export function createAuthenticatedFetch({
 
 @model("Connection")
 export class Connection extends Model({
-  config: prop<ConnectConfig>(),
+  config: prop<Frozen<ConnectConfig>>(),
+  serverVersion: prop<Frozen<{major: number; minor: number} | null>>(),
 }) {
   conn = AdminUIFetchConnection.create(
-    createAuthenticatedFetch(this.config),
-    codecsRegistry
+    createAuthenticatedFetch(this.config.data),
+    codecsRegistry,
+    this.serverVersion.data
+      ? [this.serverVersion.data.major, this.serverVersion.data.minor]
+      : undefined
   );
 
   private _runningQuery = false;

--- a/shared/studio/state/database.ts
+++ b/shared/studio/state/database.ts
@@ -15,6 +15,7 @@ import {
   prop,
   _async,
   _await,
+  frozen,
 } from "mobx-keystone";
 
 import {
@@ -148,12 +149,13 @@ export class DatabaseState extends Model({
       if (this.currentRole) {
         this.setConnection(
           new Connection({
-            config: {
+            config: frozen({
               serverUrl: instanceState.serverUrl,
               authToken: instanceState.authToken!,
               database: this.name,
               user: this.currentRole,
-            },
+            }),
+            serverVersion: frozen(instanceState.serverVersion),
           })
         );
       }

--- a/shared/studio/tabs/ai/state/index.ts
+++ b/shared/studio/tabs/ai/state/index.ts
@@ -523,7 +523,7 @@ export class AIAdminState extends Model({
     try {
       const stream: SSEStream = yield* _await(
         runRAGQuery(
-          connectConfig,
+          connectConfig.data,
           request,
           this._runningPlaygroundAbortController
         )

--- a/shared/studio/tabs/queryEditor/history.tsx
+++ b/shared/studio/tabs/queryEditor/history.tsx
@@ -18,7 +18,7 @@ import {QueryEditor, QueryHistoryItem} from "./state";
 import {renderThumbnail} from "./state/thumbnailGen";
 import {RelativeTime} from "@edgedb/common/utils/relativeTime";
 
-import styles from "./repl.module.scss";
+import styles from "./queryeditor.module.scss";
 import {useResize} from "@edgedb/common/hooks/useResize";
 import Spinner from "@edgedb/common/ui/spinner";
 import {useIsMobile} from "@edgedb/common/hooks/useMobile";

--- a/shared/studio/tabs/queryEditor/history.tsx
+++ b/shared/studio/tabs/queryEditor/history.tsx
@@ -161,9 +161,10 @@ const HistoryList = observer(function HistoryList({
         width="100%"
         estimatedItemSize={estimatedItemSize}
         itemSize={(index) =>
-          historyList[index - 1]?.showDateHeader
+          (isMobile && index == 0 ? 24 : 0) +
+          (historyList[index - 1]?.showDateHeader
             ? estimatedItemSize + 16
-            : estimatedItemSize
+            : estimatedItemSize)
         }
       >
         {({index, style}) => (

--- a/shared/studio/tabs/queryEditor/index.tsx
+++ b/shared/studio/tabs/queryEditor/index.tsx
@@ -147,15 +147,17 @@ export const QueryEditorView = observer(function QueryEditorView() {
               <span>EdgeQL Builder</span>
               {/* <BuilderTabIcon /> */}
             </div>
-            <div
-              className={cn(styles.tab, {
-                [styles.selected]:
-                  editorState.selectedEditor === EditorKind.SQL,
-              })}
-              onClick={() => editorState.setSelectedEditor(EditorKind.SQL)}
-            >
-              <span>SQL</span>
-            </div>
+            {editorState.sqlModeSupported ? (
+              <div
+                className={cn(styles.tab, {
+                  [styles.selected]:
+                    editorState.selectedEditor === EditorKind.SQL,
+                })}
+                onClick={() => editorState.setSelectedEditor(EditorKind.SQL)}
+              >
+                <span>SQL</span>
+              </div>
+            ) : null}
           </div>
 
           <div className={styles.controls}>

--- a/shared/studio/tabs/queryEditor/paramEditor/paramEditor.module.scss
+++ b/shared/studio/tabs/queryEditor/paramEditor/paramEditor.module.scss
@@ -1,21 +1,70 @@
 @import "@edgedb/common/mixins.scss";
 
 .paramEditorPanel {
-  background: #ededed;
-  overflow: auto;
-  max-height: 100%;
+  position: relative;
+  background: var(--header_background);
+  max-height: 80%;
   min-height: 88px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.12);
 
-  @include hideScrollbar;
-
-  @include darkTheme {
-    background: #363636;
+  &.horizontal {
+    max-height: none;
+    min-height: 0;
+    max-width: 50%;
+    min-width: 360px;
   }
 }
 
 .scrollWrapper {
-  flex-shrink: 0;
-  max-height: 80%;
+  width: 100%;
+  height: 100%;
+}
+
+.panelInner {
+  overflow: auto;
+  height: 100%;
+
+  @include hideScrollbar;
+}
+
+.dragHandle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 16px;
+  cursor: ns-resize;
+  z-index: 2;
+
+  &:after {
+    content: "";
+    position: absolute;
+    width: 32px;
+    height: 2px;
+    border-radius: 2px;
+    background: #c6c6c6;
+    top: 7px;
+    left: calc(50% - 16px);
+
+    @include darkTheme {
+      background: #656565;
+    }
+  }
+
+  .horizontal & {
+    right: auto;
+    height: 100%;
+    bottom: 0;
+    width: 16px;
+    cursor: ew-resize;
+
+    &:after {
+      width: 2px;
+      height: 32px;
+      left: 7px;
+      top: calc(50% - 16px);
+    }
+  }
 }
 
 .header {
@@ -23,41 +72,13 @@
   font-size: 11px;
   line-height: 13px;
   text-transform: uppercase;
-  color: #9b9b9b;
+  color: var(--tertiary_text_color);
   padding: 13px 16px;
   position: sticky;
   top: 0;
   left: 0;
-  background: #ededed;
+  background: var(--header_background);
   z-index: 1;
-
-  @include darkTheme {
-    background: #363636;
-  }
-
-  .dragHandle {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 16px;
-    cursor: ns-resize;
-
-    &:after {
-      content: "";
-      position: absolute;
-      width: 32px;
-      height: 2px;
-      border-radius: 2px;
-      background: #c6c6c6;
-      top: 7px;
-      left: calc(50% - 16px);
-
-      @include darkTheme {
-        background: #656565;
-      }
-    }
-  }
 }
 
 .paramsList {

--- a/shared/studio/tabs/queryEditor/queryeditor.module.scss
+++ b/shared/studio/tabs/queryEditor/queryeditor.module.scss
@@ -48,7 +48,7 @@ $historyTransitionTime: 0.15s;
   flex-shrink: 0;
   background: var(--header_background);
   border-radius: 12px;
-  z-index: 2;
+  z-index: 10;
   overflow: hidden;
   transition: width $historyTransitionTime;
 
@@ -97,7 +97,7 @@ $historyTransitionTime: 0.15s;
   box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.06);
   display: grid;
   grid-template-columns: 1fr auto 1fr minmax(max-content, 50%);
-  z-index: 2;
+  z-index: 5;
 
   @include darkTheme {
     border-bottom-color: var(--Grey25);

--- a/shared/studio/tabs/queryEditor/queryeditor.module.scss
+++ b/shared/studio/tabs/queryEditor/queryeditor.module.scss
@@ -7,6 +7,7 @@ $historyTransitionTime: 0.15s;
   min-height: 0;
   min-width: 0;
   display: flex;
+  font-family: "Roboto Flex Variable", sans-serif;
 
   .main {
     height: auto;
@@ -25,18 +26,174 @@ $historyTransitionTime: 0.15s;
     }
   }
 
-  &.showHistory .main {
-    margin-top: 16px;
-    margin-bottom: 16px;
-  }
-
   &.showExtendedResult {
     margin: 0 8px;
 
-    .sidebar,
-    .main {
+    .historyPanelWrapper,
+    .mainPanel {
       filter: brightness(0.95);
       pointer-events: none;
+      z-index: 0;
+    }
+
+    .history {
+      pointer-events: none;
+    }
+  }
+}
+
+.historyPanelWrapper {
+  position: relative;
+  width: 0;
+  flex-shrink: 0;
+  background: var(--header_background);
+  border-radius: 12px;
+  z-index: 2;
+  overflow: hidden;
+  transition: width $historyTransitionTime;
+
+  .showHistory & {
+    width: 194px;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.04), 0 0 4px rgba(0, 0, 0, 0.06);
+
+    @include darkTheme {
+      box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.2),
+        0px 0px 4px 0px rgba(0, 0, 0, 0.3);
+    }
+  }
+
+  // @include breakpoint(mobile) {
+  //   display: none;
+  // }
+}
+
+.mainPanel {
+  flex-grow: 1;
+  min-width: 0;
+  background: var(--app_panel_background);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.04), 0 0 4px rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  overflow: clip;
+  display: flex;
+  flex-direction: column;
+  transition: margin $historyTransitionTime;
+
+  .showHistory & {
+    margin-top: 16px;
+    margin-bottom: 16px;
+    border-radius: 0 12px 12px 0;
+  }
+
+  @include darkTheme {
+    box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.2),
+      0px 0px 4px 0px rgba(0, 0, 0, 0.3);
+  }
+}
+
+.header {
+  background: var(--header_background);
+  height: 40px;
+  border-bottom: 1px solid var(--panel_border);
+  box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.06);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr minmax(max-content, 50%);
+  z-index: 2;
+
+  @include darkTheme {
+    border-bottom-color: var(--Grey25);
+    box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.3);
+  }
+
+  .historyButton {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    color: var(--Grey60);
+    align-self: center;
+    margin-left: 4px;
+    cursor: pointer;
+
+    .showHistory & {
+      opacity: 0;
+    }
+
+    &:hover {
+      background: var(--Grey93);
+    }
+
+    @include darkTheme {
+      color: var(--Grey45);
+
+      &:hover {
+        background: var(--Grey25);
+      }
+    }
+  }
+
+  .tabs {
+    display: flex;
+    gap: 12px;
+
+    .showHistory & {
+      pointer-events: none;
+    }
+
+    .tab {
+      position: relative;
+      color: var(--tertiary_text_color);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 550;
+      line-height: 20px;
+      padding: 10px 16px;
+      cursor: pointer;
+
+      &:hover {
+        background: var(--Grey95);
+      }
+
+      &.selected {
+        color: var(--main_text_color);
+
+        &:after {
+          content: "";
+          position: absolute;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          height: 2px;
+          border-radius: 1px;
+          background: #a565cd;
+        }
+      }
+
+      @include darkTheme {
+        &:hover {
+          background: var(--Grey25);
+        }
+      }
+    }
+  }
+
+  .controls {
+    grid-column: 4;
+    display: flex;
+    gap: 12px;
+    justify-self: end;
+    align-items: center;
+    padding: 0 4px 0 16px;
+
+    .runBtn,
+    .cancelBtn {
+      height: 32px;
+      padding: 0 8px;
+      border-radius: 8px;
+    }
+    .runBtn {
+      --buttonPrimaryBackground: var(--app-accent-green);
     }
   }
 }
@@ -49,34 +206,14 @@ $historyTransitionTime: 0.15s;
   right: 0;
   bottom: 0;
   background: var(--app_panel_background);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.04), 0 0 4px rgba(0, 0, 0, 0.06);
   border-radius: 12px;
   z-index: 1;
   overflow: hidden;
-}
-
-.sidebar {
-  position: relative;
-  width: 36px;
-  flex-shrink: 0;
-  background: var(--header_background);
-  border-radius: 12px 0 0 12px;
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.04), 0 0 4px rgba(0, 0, 0, 0.06);
-  z-index: 1;
-  overflow: hidden;
-  transition: width $historyTransitionTime;
-
-  .showHistory & {
-    width: 194px;
-    border-radius: 12px;
-  }
 
   @include darkTheme {
     box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.2),
       0px 0px 4px 0px rgba(0, 0, 0, 0.3);
-  }
-
-  @include breakpoint(mobile) {
-    display: none;
   }
 }
 
@@ -87,6 +224,18 @@ $historyTransitionTime: 0.15s;
   display: flex;
   flex-direction: column;
   background: var(--app_panel_background);
+}
+
+.resultOutdatedNote,
+.resultTimestampNote {
+  font-size: 13px;
+  color: var(--tertiary_text_color);
+  font-weight: 450;
+  margin-right: 16px;
+}
+
+.resultOutdatedNote {
+  font-style: italic;
 }
 
 .inspector {
@@ -285,9 +434,6 @@ $historyTransitionTime: 0.15s;
 }
 
 .historyButton {
-  grid-row: 3;
-  align-self: end;
-
   &.disabled {
     opacity: 0.5;
     pointer-events: none;
@@ -555,6 +701,10 @@ $historyTransitionTime: 0.15s;
   flex-direction: column;
   --code-editor-bg: var(--app_panel_background);
 
+  &.horizontalSplit {
+    flex-direction: row;
+  }
+
   .editorBlockInner {
     position: relative;
     flex-grow: 1;
@@ -593,126 +743,6 @@ $historyTransitionTime: 0.15s;
 
   @include breakpoint(mobile) {
     pointer-events: unset;
-  }
-}
-
-.controls {
-  margin: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-
-  @include breakpoint(mobile) {
-    justify-content: space-between;
-    margin: 8px 24px;
-  }
-
-  label {
-    display: flex;
-    align-items: center;
-    color: #909090;
-    margin-right: 8px;
-    padding: 6px 10px;
-    cursor: pointer;
-    border-radius: 16px;
-    flex-shrink: 0;
-
-    &:hover {
-      background-color: rgba(0, 0, 0, 0.05);
-
-      @include darkTheme {
-        background-color: rgba(255, 255, 255, 0.05);
-      }
-    }
-
-    input {
-      appearance: none;
-      outline: 1px solid #d3d3d3;
-      outline-offset: 1px;
-      width: 8px;
-      height: 8px;
-      border-radius: 2px;
-      margin: 4px;
-      margin-right: 8px;
-      flex-shrink: 0;
-      cursor: inherit;
-
-      &:checked {
-        background-color: var(--app-accent-green);
-      }
-
-      @include darkTheme {
-        outline-color: #989898;
-      }
-    }
-  }
-}
-
-.runBtn {
-  --buttonPrimaryBackground: var(--app-accent-green);
-  align-self: flex-start;
-  flex-shrink: 0;
-  pointer-events: auto;
-  border-radius: 12px;
-
-  @include breakpoint(mobile) {
-    display: none;
-  }
-}
-
-.queryOptions {
-  display: flex;
-  flex-grow: 1;
-  justify-content: flex-end;
-  position: relative;
-  min-width: 0;
-
-  .queryOptionsWrapper {
-    display: flex;
-    flex-shrink: 0;
-    pointer-events: auto;
-  }
-
-  .overflowMenu {
-    display: flex;
-    cursor: pointer;
-    pointer-events: auto;
-
-    svg {
-      width: 24px;
-      height: 23px;
-      fill: #b3b3b3;
-    }
-  }
-
-  &.collapsed {
-    .queryOptionsWrapper {
-      flex-direction: column;
-      position: absolute;
-      background-color: #fff;
-      bottom: calc(100% + 8px);
-      border-radius: 18px;
-      padding: 4px;
-      display: none;
-
-      label {
-        margin: 0;
-      }
-
-      &.menuOpen {
-        display: flex;
-      }
-    }
-  }
-
-  @include darkTheme {
-    .overflowMenu svg {
-      fill: #626262;
-    }
-
-    &.collapsed .queryOptionsWrapper {
-      background-color: #353535;
-    }
   }
 }
 

--- a/shared/studio/tabs/queryEditor/queryeditor.module.scss
+++ b/shared/studio/tabs/queryEditor/queryeditor.module.scss
@@ -9,23 +9,6 @@ $historyTransitionTime: 0.15s;
   display: flex;
   font-family: "Roboto Flex Variable", sans-serif;
 
-  .main {
-    height: auto;
-    transition: margin $historyTransitionTime;
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.04), 0 0 4px rgba(0, 0, 0, 0.06);
-    border-radius: 0 12px 12px 0;
-
-    & > div:first-child {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    }
-
-    @include darkTheme {
-      box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.2),
-        0px 0px 4px 0px rgba(0, 0, 0, 0.3);
-    }
-  }
-
   &.showExtendedResult {
     margin: 0 8px;
 
@@ -62,9 +45,20 @@ $historyTransitionTime: 0.15s;
     }
   }
 
-  // @include breakpoint(mobile) {
-  //   display: none;
-  // }
+  @include isMobile {
+    position: fixed;
+    width: 100vw !important;
+    height: 100dvh;
+    top: 0;
+    border-radius: 0;
+    box-shadow: none !important;
+    transform: translateX(-100%);
+    transition: transform $historyTransitionTime;
+
+    .showHistory & {
+      transform: none;
+    }
+  }
 }
 
 .mainPanel {
@@ -88,15 +82,20 @@ $historyTransitionTime: 0.15s;
     box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.2),
       0px 0px 4px 0px rgba(0, 0, 0, 0.3);
   }
+
+  @include isMobile {
+    border-radius: 0 !important;
+    margin: 0 !important;
+  }
 }
 
 .header {
   background: var(--header_background);
-  height: 40px;
   border-bottom: 1px solid var(--panel_border);
   box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.06);
   display: grid;
   grid-template-columns: 1fr auto 1fr minmax(max-content, 50%);
+  grid-template-rows: 40px;
   z-index: 5;
 
   @include darkTheme {
@@ -196,6 +195,66 @@ $historyTransitionTime: 0.15s;
       --buttonPrimaryBackground: var(--app-accent-green);
     }
   }
+
+  .outputModeTargetRef {
+    display: contents;
+  }
+
+  @include breakpoint(tablet) {
+    grid-template-columns: 1fr auto 1fr;
+    grid-template-rows: 40px 41px;
+
+    .controls {
+      grid-column: 1 / span 3;
+      grid-row: 2;
+      justify-self: auto;
+      justify-content: end;
+      border-top: 1px solid var(--panel_border);
+    }
+  }
+
+  @include isMobile {
+    grid-template-rows: 40px;
+
+    .controls {
+      position: absolute;
+      bottom: 0;
+      border: 0;
+      left: 0;
+      right: 0;
+      padding: 8px;
+      background: linear-gradient(
+        transparent,
+        var(--app_panel_background) 32px
+      );
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
+
+      .runBtn,
+      .cancelBtn {
+        justify-self: end;
+        height: 38px;
+        border-radius: 10px;
+      }
+    }
+
+    .outputModeTargetRef {
+      display: flex;
+    }
+
+    .splitViewToggle {
+      display: none;
+    }
+
+    .outputModeToggle {
+      background: var(--Grey93);
+
+      @include darkTheme {
+        background: var(--Grey10);
+        border-color: var(--Grey18);
+      }
+    }
+  }
 }
 
 .extendedViewerContainer {
@@ -262,182 +321,12 @@ $historyTransitionTime: 0.15s;
   padding: 16px;
 }
 
-.resultHeader {
-  background: var(--header_background);
-  border-bottom: 1px solid var(--panel_border);
-  display: flex;
-  align-items: center;
-  justify-content: end;
-  height: 36px;
-  flex-shrink: 0;
-  padding: 0 8px;
-
-  &.noBorder {
-    border-bottom: 0;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
-
-    @include darkTheme {
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-    }
-  }
-}
-
-.outputModeToggle {
-  display: flex;
-
-  .label {
-    font-family: "Roboto Flex Variable", sans-serif;
-    font-size: 13px;
-    font-weight: 500;
-    line-height: 24px;
-    padding: 0 12px;
-    color: var(--tertiary_text_color);
-    cursor: pointer;
-
-    &.selected {
-      color: var(--main_text_color);
-    }
-
-    &.disabled {
-      pointer-events: none;
-      opacity: 0.5;
-    }
-  }
-
-  .toggle {
-    position: relative;
-    width: 38px;
-    height: 24px;
-    border-radius: 12px;
-    background: var(--Grey90);
-    cursor: pointer;
-
-    &:after {
-      position: absolute;
-      content: "";
-      width: 20px;
-      height: 20px;
-      top: 2px;
-      left: 2px;
-      border-radius: 10px;
-      background: #fff;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
-      transition: transform 0.25s;
-    }
-
-    &.rightSelected:after {
-      transform: translateX(14px); // 36 - 20 - 2
-    }
-
-    &.disabled {
-      pointer-events: none;
-      opacity: 0.5;
-    }
-
-    @include darkTheme {
-      background: var(--Grey14);
-
-      &:after {
-        background: var(--Grey45);
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
-      }
-    }
-  }
-}
-
 .inspectorLoading {
   height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #888;
-}
-
-.toolbar {
-  position: absolute;
-  width: 36px;
-  height: 100%;
-  display: grid;
-  grid-template-rows: 1fr auto 1fr;
-  transition: opacity $historyTransitionTime;
-
-  .showHistory & {
-    pointer-events: none;
-    opacity: 0;
-  }
-
-  .tabs {
-    grid-row: 2;
-  }
-
-  .tab {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 12px 0;
-    color: #737373;
-    cursor: pointer;
-
-    &:not(:last-child) {
-      border-bottom: 2px solid var(--app-bg);
-    }
-
-    span {
-      font-size: 12px;
-      font-weight: 500;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      writing-mode: vertical-rl;
-      transform: rotate(180deg);
-    }
-
-    svg {
-      fill: #a6a6a6;
-      margin-top: 12px;
-    }
-
-    &:hover {
-      color: #333;
-    }
-
-    &.selected {
-      background: #f5f5f5;
-
-      color: #6b6b6b;
-
-      svg {
-        fill: #b3b3b3;
-      }
-    }
-
-    @include darkTheme {
-      color: #939393;
-
-      svg {
-        fill: #7e7e7e;
-      }
-
-      &:hover {
-        color: #b3b3b3;
-      }
-
-      &.selected {
-        background: #242424;
-        color: #6b6b6b;
-
-        svg {
-          fill: #626262;
-        }
-      }
-    }
-  }
-}
-
-.historyButton {
-  &.disabled {
-    opacity: 0.5;
-    pointer-events: none;
-  }
 }
 
 .history {
@@ -458,6 +347,10 @@ $historyTransitionTime: 0.15s;
     bottom: 24px;
     right: 24px;
     z-index: 1;
+  }
+
+  @include isMobile {
+    width: 100%;
   }
 }
 
@@ -619,6 +512,10 @@ $historyTransitionTime: 0.15s;
         background-image: dashedBorderBg(#279474, 2px);
       }
     }
+
+    @include isMobile {
+      margin-top: 24px;
+    }
   }
 
   .dateHeader {
@@ -724,131 +621,5 @@ $historyTransitionTime: 0.15s;
 
   :global(.cm-line) {
     padding-right: 12px;
-  }
-}
-
-.replEditorOverlays {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  max-height: 50%;
-  pointer-events: none;
-  transition: opacity 0.1s;
-
-  .showHistory & {
-    opacity: 0;
-  }
-
-  @include breakpoint(mobile) {
-    pointer-events: unset;
-  }
-}
-
-.mobileOverlayControls {
-  display: none;
-
-  @include breakpoint(mobile) {
-    display: flex;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    justify-content: space-between;
-    z-index: 2;
-    padding: 8px 24px;
-    background: linear-gradient(
-      180deg,
-      rgba(247, 247, 247, 0) 0%,
-      #f7f7f7 100%
-    );
-
-    .mobileBtn {
-      padding: 0;
-      border: none;
-      height: 40px;
-      width: 40px;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      &:disabled {
-        opacity: 0.4;
-      }
-
-      &.running {
-        background-color: var(--accentGreen);
-        color: #fff;
-      }
-    }
-
-    .mobileHistoryIcon {
-      color: var(--grey40);
-      stroke: var(--grey97);
-    }
-
-    .mobileRunIcon {
-      path {
-        fill: #fff;
-      }
-
-      circle {
-        fill: #2cb88e;
-      }
-    }
-
-    @include darkTheme {
-      background: linear-gradient(
-        180deg,
-        rgba(20, 20, 20, 0) 0%,
-        #141414 100%
-      );
-
-      .mobileHistoryIcon {
-        color: var(--grey70);
-        stroke: var(--grey8);
-      }
-
-      .mobileRunIcon {
-        path {
-          fill: #141414;
-        }
-
-        circle {
-          fill: var(--accentGreen);
-        }
-      }
-    }
-  }
-}
-
-.mobileHistory {
-  display: none;
-
-  @include breakpoint(mobile) {
-    display: block;
-    width: 100vw;
-    height: 100vh;
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 10;
-    background-color: var(--fullscreenOverlayBg);
-
-    .title {
-      @include breakpoint(mobile) {
-        text-align: center;
-        font-family: Roboto;
-        font-size: 20px;
-        font-weight: 700;
-        line-height: 24px;
-      }
-    }
-
-    .historyPanel {
-      width: 100%;
-    }
   }
 }

--- a/shared/studio/tabs/queryEditor/state/index.ts
+++ b/shared/studio/tabs/queryEditor/state/index.ts
@@ -40,7 +40,10 @@ import {dbCtx} from "../../../state";
 import {connCtx} from "../../../state/connection";
 import {instanceCtx} from "../../../state/instance";
 
-import {SplitViewState} from "@edgedb/common/ui/splitView/model";
+import {
+  SplitViewDirection,
+  SplitViewState,
+} from "@edgedb/common/ui/splitView/model";
 import {
   paramsQueryCtx,
   QueryParamsEditor,
@@ -180,8 +183,6 @@ export class QueryEditor extends Model({
   ),
   _sqlParamsEditor: prop(() => new QueryParamsEditor({lang: Language.SQL})),
 
-  splitView: prop(() => new SplitViewState({})),
-
   selectedEditor: prop<EditorKind>(EditorKind.EdgeQL).withSetter(),
 
   showHistory: prop(false),
@@ -208,6 +209,24 @@ export class QueryEditor extends Model({
     [EditorKind.SQL]: false,
     [EditorKind.VisualBuilder]: false,
   };
+
+  @computed
+  get currentQueryEdited() {
+    return this.queryIsEdited[this.selectedEditor];
+  }
+
+  _splitViews: {[key in EditorKind]: SplitViewState} = {
+    [EditorKind.EdgeQL]: new SplitViewState({}),
+    [EditorKind.SQL]: new SplitViewState({
+      direction: SplitViewDirection.vertical,
+    }),
+    [EditorKind.VisualBuilder]: new SplitViewState({}),
+  };
+
+  @computed
+  get splitView() {
+    return this._splitViews[this.selectedEditor];
+  }
 
   @computed
   get paramsEditor() {
@@ -287,6 +306,7 @@ export class QueryEditor extends Model({
   get canRunQuery() {
     return (
       !this.queryRunning &&
+      !this.showHistory &&
       (this.selectedEditor === EditorKind.EdgeQL ||
       this.selectedEditor === EditorKind.SQL
         ? !this.paramsEditor!.hasErrors &&

--- a/shared/studio/tabs/queryEditor/state/index.ts
+++ b/shared/studio/tabs/queryEditor/state/index.ts
@@ -183,7 +183,7 @@ export class QueryEditor extends Model({
   ),
   _sqlParamsEditor: prop(() => new QueryParamsEditor({lang: Language.SQL})),
 
-  selectedEditor: prop<EditorKind>(EditorKind.EdgeQL).withSetter(),
+  selectedEditor: prop<EditorKind>(EditorKind.EdgeQL),
 
   showHistory: prop(false),
   queryHistory: prop<QueryHistoryItem[]>(() => [null as any]),
@@ -194,6 +194,20 @@ export class QueryEditor extends Model({
 
   @computed get queryRunning() {
     return this.runningQueryAbort != null;
+  }
+
+  @computed
+  get sqlModeSupported(): boolean {
+    const serverVersion = instanceCtx.get(this)!.serverVersion;
+    return !serverVersion || serverVersion.major >= 6;
+  }
+
+  @modelAction
+  setSelectedEditor(kind: EditorKind) {
+    if (kind === EditorKind.SQL && !this.sqlModeSupported) {
+      return;
+    }
+    this.selectedEditor = kind;
   }
 
   @observable.shallow

--- a/shared/studio/tabs/repl/commands.tsx
+++ b/shared/studio/tabs/repl/commands.tsx
@@ -1,8 +1,9 @@
 import {CommandOutputKind, CommandResult} from "./state/commands";
 
 import styles from "./repl.module.scss";
+import {Repl} from "./state";
 
-export function renderCommandResult(result: CommandResult) {
+export function renderCommandResult(state: Repl, result: CommandResult) {
   const ctrlKey = navigator.platform.toLowerCase().includes("mac")
     ? "Cmd"
     : "Ctrl";
@@ -17,13 +18,17 @@ export function renderCommandResult(result: CommandResult) {
           <div className={styles.command}>{ctrlKey}+ArrowUp/ArrowDown</div>
           <div className={styles.info}>Navigate query history</div>
 
-          <div className={styles.heading}>Settings</div>
-          <div className={styles.command}>
-            \set language {"("}edgeql | sql{")"},
-            <br />
-            \edgeql, \sql
-          </div>
-          <div className={styles.info}>Set the query language</div>
+          {state.sqlModeSupported ? (
+            <>
+              <div className={styles.heading}>Settings</div>
+              <div className={styles.command}>
+                \set language {"("}edgeql | sql{")"},
+                <br />
+                \edgeql, \sql
+              </div>
+              <div className={styles.info}>Set the query language</div>
+            </>
+          ) : null}
 
           <div className={styles.heading}>Introspection</div>
           <div className={styles.subheading}>

--- a/shared/studio/tabs/repl/index.tsx
+++ b/shared/studio/tabs/repl/index.tsx
@@ -762,7 +762,7 @@ const ReplHistoryItem = observer(function ReplHistoryItem({
       output = <div className={styles.queryStatus}>OK: {item.status}</div>;
     }
   } else if (item.commandResult) {
-    output = renderCommandResult(item.commandResult.data);
+    output = renderCommandResult(state, item.commandResult.data);
   } else {
     output = (
       <>

--- a/shared/studio/tabs/repl/index.tsx
+++ b/shared/studio/tabs/repl/index.tsx
@@ -886,11 +886,11 @@ const ReplHistoryItem = observer(function ReplHistoryItem({
               ) : null}
             </div>
           </CustomScrollbars>
+          {headerExtra}
           <div className={styles.historyTime}>
             {new Date(item.timestamp).toLocaleTimeString()}
           </div>
         </div>
-        {headerExtra}
       </div>
       {output ? (
         !hasScroll ? (

--- a/shared/studio/tabs/repl/repl.module.scss
+++ b/shared/studio/tabs/repl/repl.module.scss
@@ -384,6 +384,16 @@
     user-select: none;
     margin: 14px 12px 0 16px;
   }
+
+  @include isMobile {
+    .historyPrompt,
+    .historyQueryCode {
+      padding-top: 14px;
+    }
+    .historyTime {
+      margin-top: 16px;
+    }
+  }
 }
 
 .explain .historyHeader {

--- a/shared/studio/tabs/repl/repl.module.scss
+++ b/shared/studio/tabs/repl/repl.module.scss
@@ -315,9 +315,10 @@
 }
 
 .resultModeHeader {
-  display: flex;
-  justify-content: end;
-  padding-bottom: 8px;
+  padding: 4px;
+  margin-left: 8px;
+  margin-right: -8px;
+  z-index: 1;
 }
 
 .historyQuery {

--- a/shared/studio/tabs/repl/state/commands.ts
+++ b/shared/studio/tabs/repl/state/commands.ts
@@ -116,8 +116,15 @@ export async function handleSlashCommand(
     }
     case "edgeql":
     case "sql": {
-      item.setCommandResult({kind: CommandOutputKind.none});
-      repl.setLanguage(command === "sql" ? ReplLang.SQL : ReplLang.EdgeQL);
+      if (command === "edgeql" || repl.sqlModeSupported) {
+        item.setCommandResult({kind: CommandOutputKind.none});
+        repl.setLanguage(command === "sql" ? ReplLang.SQL : ReplLang.EdgeQL);
+      } else {
+        item.setCommandResult({
+          kind: CommandOutputKind.error,
+          msg: `This version of Gel does not support SQL mode`,
+        });
+      }
       break;
     }
     case "clear": {

--- a/shared/studio/tabs/repl/state/index.ts
+++ b/shared/studio/tabs/repl/state/index.ts
@@ -217,11 +217,20 @@ export class Repl extends Model({
 
   scrollRef: HTMLDivElement | null = null;
 
+  @computed
+  get sqlModeSupported(): boolean {
+    const serverVersion = instanceCtx.get(this)!.serverVersion;
+    return !serverVersion || serverVersion.major >= 6;
+  }
+
   @observable
   language = ReplLang.EdgeQL;
 
   @action
   setLanguage(lang: ReplLang) {
+    if (lang === ReplLang.SQL && !this.sqlModeSupported) {
+      return;
+    }
     this.language = lang;
   }
 

--- a/shared/studio/tabs/schema/index.tsx
+++ b/shared/studio/tabs/schema/index.tsx
@@ -55,7 +55,7 @@ export const SchemaView = observer(function SchemaView() {
         {isMobile ? (
           <LabelsSwitch
             className={styles.viewSwitch}
-            labels={["text", "graph"]}
+            labels={["Text", "Graph"]}
             value={isGraphView ? switchState.right : switchState.left}
             onChange={() =>
               schemaState.setViewType(

--- a/shared/studio/tabs/schema/schema.module.scss
+++ b/shared/studio/tabs/schema/schema.module.scss
@@ -190,8 +190,8 @@
 .viewSwitch {
   position: absolute;
   bottom: 8px;
-  left: calc(50% - 54.4px);
-  border-radius: 22px;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .switcherLabel {

--- a/web/src/state/models/app.ts
+++ b/web/src/state/models/app.ts
@@ -52,7 +52,12 @@ export const appCtx = createContext<App>();
 @model("App")
 export class App extends Model({
   instanceState: prop(
-    () => new InstanceState({serverUrl, authToken, authUsername})
+    () =>
+      new InstanceState({
+        serverUrl,
+        authToken,
+        authUsername,
+      })
   ),
 }) {
   onInit() {

--- a/web/tests/_testenv.js
+++ b/web/tests/_testenv.js
@@ -4,6 +4,7 @@ import {Builder, Browser, By, until, Key, error} from "selenium-webdriver";
 import chrome from "selenium-webdriver/chrome.js";
 
 let opts = new chrome.Options();
+opts.windowSize({width: 1200, height: 900});
 
 if (process.env["CI"] || !process.argv.slice(2).includes("--no-headless")) {
   opts.addArguments("--headless=new");

--- a/web/tests/clientSettings.test.ts
+++ b/web/tests/clientSettings.test.ts
@@ -42,7 +42,7 @@ describe("clientSettings:", () => {
 
     const resultHiddenNote = await driver.wait(
       until.elementLocated(
-        ByUIClass("repl_queryResult", "inspector_resultsHidden")
+        ByUIClass("queryeditor_queryResult", "inspector_resultsHidden")
       )
     );
     expect(
@@ -51,7 +51,7 @@ describe("clientSettings:", () => {
 
     // check only 10 results returned
     const results = await driver.findElements(
-      ByUIClass("repl_queryResult", "inspector_scalar_number")
+      ByUIClass("queryeditor_queryResult", "inspector_scalar_number")
     );
     expect(results.length).toBe(10);
   });

--- a/web/tests/queryEditor.test.ts
+++ b/web/tests/queryEditor.test.ts
@@ -23,15 +23,17 @@ describe("queryEditor:", () => {
       );
 
       // run the query
-      const runButton = await driver.findElement(ByUIClass("repl_runBtn"));
+      const runButton = await driver.findElement(
+        ByUIClass("queryeditor_runBtn")
+      );
       await runButton.click();
 
       const errorElement = await driver.wait(
-        until.elementLocated(ByUIClass("repl_queryError"))
+        until.elementLocated(ByUIClass("queryeditor_queryError"))
       );
 
       const error = await errorElement.findElement(
-        ByUIClass("repl_errorName")
+        ByUIClass("queryeditor_errorName")
       );
 
       expect((await error.getText()).includes("InvalidReferenceError")).toBe(
@@ -39,7 +41,7 @@ describe("queryEditor:", () => {
       );
 
       const errorHint = await errorElement.findElement(
-        ByUIClass("repl_errorHint")
+        ByUIClass("queryeditor_errorHint")
       );
 
       expect(await errorHint.getText()).toBe(
@@ -59,15 +61,17 @@ describe("queryEditor:", () => {
       );
 
       // run the query
-      const runButton = await driver.findElement(ByUIClass("repl_runBtn"));
+      const runButton = await driver.findElement(
+        ByUIClass("queryeditor_runBtn")
+      );
       await runButton.click();
 
       const errorElement = await driver.wait(
-        until.elementLocated(ByUIClass("repl_queryError"))
+        until.elementLocated(ByUIClass("queryeditor_queryError"))
       );
 
       const error = await errorElement.findElement(
-        ByUIClass("repl_errorName")
+        ByUIClass("queryeditor_errorName")
       );
 
       expect((await error.getText()).includes("EdgeQLSyntaxError")).toBe(true);
@@ -85,11 +89,13 @@ describe("queryEditor:", () => {
       );
 
       // run the query
-      const runButton = await driver.findElement(ByUIClass("repl_runBtn"));
+      const runButton = await driver.findElement(
+        ByUIClass("queryeditor_runBtn")
+      );
       await runButton.click();
 
       const inspector = await driver.wait(
-        until.elementLocated(ByUIClass("repl_inspector"))
+        until.elementLocated(ByUIClass("queryeditor_inspector"))
       );
 
       const results = await inspector.findElements(
@@ -123,7 +129,7 @@ describe("queryEditor:", () => {
 
       // wait for the view window to open
       const viewWindow = await driver.wait(
-        until.elementLocated(ByUIClass("repl_extendedViewerContainer"))
+        until.elementLocated(ByUIClass("queryeditor_extendedViewerContainer"))
       );
 
       // linewrap / show whitespace
@@ -142,7 +148,7 @@ describe("queryEditor:", () => {
       (await viewWindow.findElement(ByUIClass("shared_closeAction"))).click();
 
       await waitUntilElementNotLocated(
-        ByUIClass("repl_extendedViewerContainer")
+        ByUIClass("queryeditor_extendedViewerContainer")
       );
     });
 
@@ -154,7 +160,9 @@ describe("queryEditor:", () => {
       await editor.sendKeys("select 1 + 1");
 
       // run the query and populate the history
-      const runButton = await driver.findElement(ByUIClass("repl_runBtn"));
+      const runButton = await driver.findElement(
+        ByUIClass("queryeditor_runBtn")
+      );
       await runButton.click();
 
       // write something else in the editor
@@ -164,21 +172,27 @@ describe("queryEditor:", () => {
       // save the current editor text to be able to compare it later with the other one from history
       const draftQuery = await editor.getText();
 
-      (await driver.findElement(ByUIClass("repl_historyButton"))).click();
+      (
+        await driver.findElement(ByUIClass("queryeditor_historyButton"))
+      ).click();
 
-      await driver.wait(until.elementLocated(ByUIClass("repl_history")));
+      await driver.wait(
+        until.elementLocated(ByUIClass("queryeditor_history"))
+      );
       // the element get rerendered and we need to get it again in order to avoid stale reference err
-      await driver.wait(until.elementLocated(ByUIClass("repl_history")));
+      await driver.wait(
+        until.elementLocated(ByUIClass("queryeditor_history"))
+      );
 
       // click on first history query (that is not draft query)
       const firstItem = await driver.findElements(
-        ByUIClass("repl_historyItem")
+        ByUIClass("queryeditor_historyItem")
       );
       await firstItem[1].click();
       // click on edit button
       (
         await driver.wait(
-          until.elementLocated(ByUIClass("repl_loadButton")),
+          until.elementLocated(ByUIClass("queryeditor_loadButton")),
           2000
         )
       ).click();
@@ -186,17 +200,17 @@ describe("queryEditor:", () => {
       expect(await editor.getText()).not.toBe(draftQuery);
 
       // history sidebar is closed
-      await waitUntilElementNotLocated(ByUIClass("repl_history"));
+      await waitUntilElementNotLocated(ByUIClass("queryeditor_history"));
     });
   });
 
   describe("builder", () => {
     beforeAll(async () => {
       const editorTabs = await driver.wait(
-        until.elementLocated(ByUIClass("repl_tabs"))
+        until.elementLocated(ByUIClass("queryeditor_tabs"))
       );
 
-      const tabs = await editorTabs.findElements(ByUIClass("repl_tab"));
+      const tabs = await editorTabs.findElements(ByUIClass("queryeditor_tab"));
       // click on builder tab
       await driver.actions({async: true}).click(tabs[1]).perform();
       // wait for builder window to show

--- a/web/tests/simple.test.ts
+++ b/web/tests/simple.test.ts
@@ -8,7 +8,7 @@ test("select version query", async () => {
   );
   await editor.sendKeys("select sys::get_version_as_str()");
 
-  const runButton = driver.findElement(ByUIClass("repl_runBtn"));
+  const runButton = driver.findElement(ByUIClass("queryeditor_runBtn"));
   await runButton.click();
 
   const versionStrEl = await driver.wait(


### PR DESCRIPTION
Closes #379

Todo:
- [x] Fixup mobile design

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ec768e9d-b819-4ace-8419-8720addaa9b2">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/23caf376-adcb-4661-867f-95c2e4259c0d">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/072416fd-6724-4b80-a444-725be3936064">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/efd7dae3-6714-4343-a15e-57d0bb39e38a">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4b252a26-6326-462b-8e16-2394e02f2743">

Mid width:
<img width="929" alt="image" src="https://github.com/user-attachments/assets/c4e3d9d0-d8b3-4493-872b-0c9214368e31">
Mobile:
<img width="421" alt="image" src="https://github.com/user-attachments/assets/886a104d-d3ea-4697-abbf-e062b75e55d4">
<img width="420" alt="image" src="https://github.com/user-attachments/assets/931d3e0f-0afe-4089-b3d4-b17e72effa40">


Also updated repl to use tree/table switcher:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e31dddbc-21fb-4fb7-aea2-38a3087cceee">
